### PR TITLE
Changed urls.py in makeabiltylab to route / to website

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+.PHONY: run
+.PHONY: migrate
+
+run:
+	python manage.py runserver
+
+migrate:
+	python manage.py migrate

--- a/makeabilitylab/urls.py
+++ b/makeabilitylab/urls.py
@@ -20,6 +20,7 @@ from django.conf.urls.static import static
 from django.conf import settings
 
 urlpatterns = [
-    url(r'^website/', include('website.urls')),
+    #Info on how to route root to website was found here http://stackoverflow.com/questions/7580220/django-urls-howto-map-root-to-app
+    url(r'', include('website.urls')),
     url(r'^admin/', admin.site.urls),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
I updated the routing under makeabilitylab/urls.py to route hostname/ to websites. This means you no longer need to type hostname:port/website/ to access the main page. Information on how to do this was found at http://stackoverflow.com/questions/7580220/django-urls-howto-map-root-to-app. In testing hostname/admin still works and no routing issues appear to have been created.

---

I also added a makefile, I forgot that it was in there but it's useful for anyone with make installed. The makefile has the following commands:

run: python manage.py runserver
migrate python manage.py migrate

I just made it so that I could run the server without typing so much. If you don't want it in the repo I'll remove it and push again.
