### PR TITLE
Fixes bibtex syntax error

### DIFF
--- a/website/models/publication.py
+++ b/website/models/publication.py
@@ -244,7 +244,7 @@ class Publication(models.Model):
         bibtex += self.get_bibtex_id() + newline
 
         # start author block
-        bibtex += " author = {"
+        bibtex += " author={"
 
         author_idx = 0
         num_authors = self.authors.count()
@@ -256,7 +256,7 @@ class Publication(models.Model):
                 bibtex += " and "
 
             author_idx += 1
-        bibtex += "}" + newline
+        bibtex += "}," + newline
         # end author block
 
         bibtex += " title={{{}}},{}".format(self.title, newline)


### PR DESCRIPTION
Fixes #1007 

Fixes a syntax error in the bibtex that we generate. We were missing a comma after the author field. I also removed the spaces around the `=` sign for consistency :)

Before
<img width="717" alt="Screen Shot 2022-08-04 at 11 13 28 AM" src="https://user-images.githubusercontent.com/6518824/182927377-10edaf17-6089-40d3-8f58-1d20d5a1fc6f.png">

After
<img width="717" alt="Screen Shot 2022-08-04 at 11 15 45 AM" src="https://user-images.githubusercontent.com/6518824/182927410-59f27141-ec62-4067-9058-4aaab837a7d6.png">

