### PR TITLE
Update news to use slugs

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -80,6 +80,11 @@ echo "4. Running 'python manage.py delete_unused_files' to delete unused files i
 echo "******************************************"
 python manage.py delete_unused_files
 
+echo "****************** STEP 4.1/5: docker-entrypoint.sh ************************"
+echo "4.1 Running 'python manage.py generate_slugs_for_old_news_items' to generate slugs for old news items"
+echo "******************************************"
+python manage.py generate_slugs_for_old_news_items
+
 # Start server
 echo "Starting server"
 echo "****************** STEP 5/5: docker-entrypoint.sh ************************"

--- a/website/management/commands/generate_slugs_for_old_news_items.py
+++ b/website/management/commands/generate_slugs_for_old_news_items.py
@@ -1,0 +1,27 @@
+from django.core.management.base import BaseCommand
+from django.utils.text import slugify
+from website.models import News
+
+class Command(BaseCommand):
+    help = 'Generate slugs for old news items. You should only need to run this command once'
+
+    def handle(self, *args, **options):
+        # Go through news items where there is no slug and generate a slug for them
+        news_items_without_slug = News.objects.filter(slug__isnull=True) | News.objects.filter(slug='')
+        for news_item_without_slug in news_items_without_slug:
+            print(f"News id {news_item_without_slug.id}: Generating slug for news item '{news_item_without_slug.title}'")
+            original_slug = slugify(news_item_without_slug.title)
+            new_slug = original_slug
+            num = 2
+
+            # check to ensure that the slug is unique
+            while News.objects.filter(slug=new_slug).exists():
+                new_slug = f"{original_slug}-{num}"
+                num += 1
+
+            # save the slug
+            print(f"News id {news_item_without_slug.id}: Saving slug '{new_slug}' for news item '{news_item_without_slug.title}'")
+            news_item_without_slug.slug = new_slug
+            news_item_without_slug.save()
+
+        

--- a/website/templates/snippets/display_news_blurb_sidebar_snippet.html
+++ b/website/templates/snippets/display_news_blurb_sidebar_snippet.html
@@ -1,4 +1,4 @@
-{# This is a reusable template for displaying a person #}
+{# This is a reusable template for displaying a news blurb #}
 {# See: https://docs.djangoproject.com/en/dev/ref/templates/builtins/#include #}
 
 {% load static %}
@@ -22,7 +22,7 @@
     <div class="news_info">
         <!-- https://css-tricks.com/line-clampin/ This seems to be a good way to do multi line wrapping, also referenced in relevant news.css file -->
         <div class="news_title line-clamp">
-            <a href="{% url 'website:news' news_item.id %}">
+            <a href="{% url 'website:news_item_by_slug' slug=news_item.slug %}">
                 <p>{{ news_item.title }}</p>
             </a>
         </div>

--- a/website/templates/website/base.html
+++ b/website/templates/website/base.html
@@ -479,7 +479,7 @@
 
                 {% for news_item in recent_news %}
                     <div class="row">
-                        <a href="{% url 'website:news' news_item.id %}">
+                        <a href="{% url 'website:news_item_by_slug' slug=news_item.slug %}">
                             <div class="col-xs-3" style="white-space:nowrap;min-width:115px">
                                 {#  Date formats here: https://docs.djangoproject.com/en/1.11/ref/templates/builtins/#std:templatefilter-date #}
                                 <p>{{ news_item.date|date:"N d, Y" }}</p>

--- a/website/templates/website/index.html
+++ b/website/templates/website/index.html
@@ -47,7 +47,7 @@
             <div style="width: 200px">
                 {% for news_item in news|slice:"5" %}
                     <p class="line-clamp" style="margin-bottom:15px; color:white; font-family:Roboto;">
-                        <a href="{% url 'website:news' news_item.id %}">
+                        <a href="{% url 'website:news_item_by_slug' slug=news_item.slug %}">
                             <span style="color:rgb(245,245,245);"><span style="font-family: roboto-bold; font-weight: 700;">{{ news_item.date }}.</span> {{ news_item.title }}</span>
                         </a>
                     </p>

--- a/website/templates/website/news-listing.html
+++ b/website/templates/website/news-listing.html
@@ -35,7 +35,8 @@
         {% for news_item in news %}
           <div class="news-card">
             <div class="news-image">
-              <a href="{% url 'website:news' slug=news_item.slug %}">
+              {% comment %} The 'news_item_by_slug' refers to the name in urls.py for the path pattern to use here {% endcomment %}
+              <a href="{% url 'website:news_item_by_slug' slug=news_item.slug %}">
                 {% if news_item.image %}
                   <img src="{% thumbnail news_item.image 362x217 box=news_item.cropping crop detail upscale %}" 
                     alt="{{news_item.alt_text}}"/>
@@ -45,7 +46,7 @@
                 {% endif %}
               </a>
             </div>
-            <h3 class="news-card-headline"><a href="{% url 'website:news' slug=news_item.slug %}">{{ news_item.title }}</a></h3>
+            <h3 class="news-card-headline"><a href="{% url 'website:news_item_by_slug' slug=news_item.slug %}">{{ news_item.title }}</a></h3>
             <div class="news-card-byline">
               <span class="news-card-author">BY <a href="{% url 'website:member' member_id=news_item.author.id %}">{{ news_item.author }}</a></span>
               <span class="news-card-date">• {{ news_item.short_date }}</span>

--- a/website/templates/website/news-listing.html
+++ b/website/templates/website/news-listing.html
@@ -32,22 +32,23 @@
       {% endif %}
 
       <div class="news-grid">
-        {% for n in news %}
+        {% for news_item in news %}
           <div class="news-card">
             <div class="news-image">
-              <a href="{% url 'website:news' news_id=n.id %}">
-                {% if n.image %}
-                  <img src="{% thumbnail n.image 362x217 box=news.cropping crop detail upscale %}" alt="{{n.alt_text}}"/>
+              <a href="{% url 'website:news' slug=news_item.slug %}">
+                {% if news_item.image %}
+                  <img src="{% thumbnail news_item.image 362x217 box=news_item.cropping crop detail upscale %}" 
+                    alt="{{news_item.alt_text}}"/>
                 {% else %}
-                  <img src="{% static n.default_news_image_filename %}" style="max-height:217px;" 
+                  <img src="{% static news_item.default_news_image_filename %}" style="max-height:217px;" 
                     alt="This is a default news page icon for when there are no thumbnails" />
                 {% endif %}
               </a>
             </div>
-            <h3 class="news-card-headline"><a href="{% url 'website:news' news_id=n.id %}">{{ n.title }}</a></h3>
+            <h3 class="news-card-headline"><a href="{% url 'website:news' slug=news_item.slug %}">{{ news_item.title }}</a></h3>
             <div class="news-card-byline">
-              <span class="news-card-author">BY <a href="{% url 'website:member' member_id=n.author.id %}">{{ n.author }}</a></span>
-              <span class="news-card-date">• {{ n.short_date }}</span>
+              <span class="news-card-author">BY <a href="{% url 'website:member' member_id=news_item.author.id %}">{{ news_item.author }}</a></span>
+              <span class="news-card-date">• {{ news_item.short_date }}</span>
             </div>
           </div>
         {% endfor %}

--- a/website/templates/website/news.html
+++ b/website/templates/website/news.html
@@ -59,14 +59,14 @@
 	    <div class="row">
 		<h3 class="news-type-label">Recent News from <a href="{% url 'website:member' news.author.get_url_name %}">{{news.author.first_name}}</a></h3>
 		<div class="well news-well">
-		    {% for item in author_news %}
+		    {% for news_item in author_news %}
 		    <!-- Create a row for each news item which has been passed in -->
 		    <div class="row news_header">
 			<!-- TODO link to the full news item -->
 			<a href="">
 			    <!-- Use the items image if it exists, otherwise use the default icon -->
-			    {% if item.image %}
-			    <img src="{% thumbnail item.image 250x250 box=item.cropping crop detail %}" class="news_image" height="50" width="50" alt="{{item.alt_text}}">
+			    {% if news_item.image %}
+			    <img src="{% thumbnail news_item.image 250x250 box=news_item.cropping crop detail %}" class="news_image" height="50" width="50" alt="{{news_item.alt_text}}">
 			    {% else %}
 			    <img src="{% static 'website/img/news_icon.png' %}" class="news_image" height="50" width="50">			
 			    {% endif %}
@@ -75,18 +75,18 @@
 			    <!-- https://css-tricks.com/line-clampin/ This seems to be a good way to do multi line wrapping, also referenced in relevant news.css file -->
 			    <div class="news_title line-clamp">
 				<!-- TODO link to the full news item -->
-				<a href="{% url 'website:news' item.id %}">
-				    <p>{{item.title}}</p>
+				<a href="{% url 'website:news_item_by_slug' slug=news_item.slug %}">
+				    <p>{{news_item.title}}</p>
 				</a>
 			    </div>
-			    <p class="news_date">{{item.short_date}} | <a href="{% url 'website:member' item.author.get_url_name %}">{{item.author.first_name}}</a></p><!--</p><p class="news_date">{{item.author}}</p>-->
+			    <p class="news_date">{{news_item.short_date}} | <a href="{% url 'website:member' news_item.author.get_url_name %}">{{news_item.author.first_name}}</a></p><!--</p><p class="news_date">{{news_item.author}}</p>-->
 			</div>
 		    </div>
 		    <div class="row news_body">
 			<!-- Truncation now uses a set number of lines which can be modified in news.css content-clamp class by changing -webkit-line-clamp -->
 			<div class="news_content content-clamp">
 			    {% autoescape off %}
-			    <p>{{ item.content | removehtmltags }}</p>
+			    <p>{{ news_item.content | removehtmltags }}</p>
 			    {% endautoescape %}
 			</div>
 		    </div>
@@ -100,14 +100,14 @@
 		<h3 class="news-type-label">Recent News from <a href="{% url 'website:project' project.short_name %}">{{project.name}}</a></h3>
 		{% endif %}
 		<div class="well news-well">
-		    {% for item in proj_news %}
+		    {% for news_item in proj_news %}
 		    <!-- Create a row for each news item which has been passed in -->
 		    <div class="row news_header">
 			<!-- TODO link to the full news item -->
 			<a href="">
 			    <!-- Use the items image if it exists, otherwise use the default icon -->
-			    {% if item.image %}
-			    <img src="{% thumbnail item.image 250x250 box=item.cropping crop detail %}" class="news_image" height="50" width="50" alt="{{item.alt_text}}">
+			    {% if news_item.image %}
+			    <img src="{% thumbnail news_item.image 250x250 box=news_item.cropping crop detail %}" class="news_image" height="50" width="50" alt="{{news_item.alt_text}}">
 			    {% else %}
 			    <img src="{% static 'website/img/news_icon.png' %}" class="news_image" height="50" width="50">			
 			    {% endif %}
@@ -116,18 +116,18 @@
 			    <!-- https://css-tricks.com/line-clampin/ This seems to be a good way to do multi line wrapping, also referenced in relevant news.css file -->
 			    <div class="news_title line-clamp">
 				<!-- TODO link to the full news item -->
-				<a href="{% url 'website:news' item.id %}">
-				    <p>{{item.title}}</p>
+				<a href="{% url 'website:news_item_by_slug' slug=news_item.slug %}">
+				    <p>{{news_item.title}}</p>
 				</a>
 			    </div>
-			    <p class="news_date">{{item.short_date}} | <a href="{% url 'website:member' item.author.get_url_name %}">{{item.author.first_name}}</a></p><!--</p><p class="news_date">{{item.author}}</p>-->
+			    <p class="news_date">{{news_item.short_date}} | <a href="{% url 'website:member' news_item.author.get_url_name %}">{{news_item.author.first_name}}</a></p><!--</p><p class="news_date">{{news_item.author}}</p>-->
 			</div>
 		    </div>
 		    <div class="row news_body">
 			<!-- Truncation now uses a set number of lines which can be modified in news.css content-clamp class by changing -webkit-line-clamp -->
 			<div class="news_content content-clamp">
 			    {% autoescape off %}
-			    <p>{{item.content}}</p>
+			    <p>{{news_item.content}}</p>
 			    {% endautoescape %}
 			</div>
 		    </div>

--- a/website/urls.py
+++ b/website/urls.py
@@ -25,8 +25,11 @@ urlpatterns = [
     re_path(r'^projects/(?P<project_name>[a-zA-Z ]+)/$', views.project, name='project'),
     re_path(r'^project/(?P<project_name>[a-zA-Z ]+)/$', views.project, name='project'),
     re_path(r'^news/$', views.news_listing, name='news_listing'),
-    path('news/<slug:slug>/', views.news, name='news'),
-    re_path(r'^news/(?P<news_id>[0-9]+)/$', views.news, name='news'),
+
+    # First try to match on the news id (for historical compatibility) then match on the slug
+    path('news/<int:id>/', views.news, name='news_item_by_id'),
+    path('news/<slug:slug>/', views.news, name='news_item_by_slug'),
+    
     re_path(r'^faq/$', views.faq, name='faq'),
     
     

--- a/website/urls.py
+++ b/website/urls.py
@@ -1,7 +1,7 @@
 # Django 4+ removed django.conf.urls.url()
 # https://stackoverflow.com/a/70319607
 # from django.conf.urls import url
-from django.urls import re_path
+from django.urls import re_path, path
 
 from . import views
 from rest_framework.urlpatterns import format_suffix_patterns
@@ -25,16 +25,15 @@ urlpatterns = [
     re_path(r'^projects/(?P<project_name>[a-zA-Z ]+)/$', views.project, name='project'),
     re_path(r'^project/(?P<project_name>[a-zA-Z ]+)/$', views.project, name='project'),
     re_path(r'^news/$', views.news_listing, name='news_listing'),
+    path('news/<slug:slug>/', views.news, name='news'),
     re_path(r'^news/(?P<news_id>[0-9]+)/$', views.news, name='news'),
     re_path(r'^faq/$', views.faq, name='faq'),
+    
     
     # JEF (Oct 31, 2022): this makes it sound you can just type in a project name
     # and we'll try to go to that project without putting in 'projects' or 'project'
     # For example, http://makeabilitylab.cs.uw.edu/soundwatch will go to
     # http://makeabilitylab.cs.uw.edu/project/soundwatch 
-    #
-    # Update: had to remove this as it prevented us from going to the admin page, oops!
-    # Needs more thought.
     re_path(r'(?P<project_name>[a-zA-Z ]+)/$', views.redirect_project, name='project'),
 ]
 

--- a/website/utils/ml_utils.py
+++ b/website/utils/ml_utils.py
@@ -8,6 +8,20 @@ import random
 from django.conf import settings 
 from operator import itemgetter
 
+from django.utils.text import slugify
+
+# In this function, slugify_max, we first generate the slug using slugify. Then 
+# we check if its length is less than or equal to max_length. If it is, we return the 
+# slug as is. If it’s longer, we truncate it to max_length characters. The rsplit('-', 1)[0] part 
+# ensures that we don’t cut off in the middle of a word
+def slugify_max(text, max_length=100):
+    """Returns a slugified version of a given text up to a max length"""
+    slug = slugify(text)
+    if len(slug) <= max_length:
+        return slug
+    trimmed_slug = slug[:max_length].rsplit('-', 1)[0]
+    return trimmed_slug
+
 def get_school_abbreviated(school_name):
     """Returns the school abbreviation for a given school name"""
     school_low = school_name.lower()

--- a/website/views/news.py
+++ b/website/views/news.py
@@ -3,6 +3,7 @@ from website.models import News
 
 import website.utils.ml_utils as ml_utils 
 from django.shortcuts import render, get_object_or_404
+from django.http import Http404
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 
 # For logging
@@ -14,11 +15,19 @@ _logger = logging.getLogger(__name__)
 
 # This method and the news functionality in general was written by Johnson Kuang
 # def news(request, news_id):
-def news(request, slug):
+def news(request, slug=None, id=None):
     func_start_time = time.perf_counter()
+
+    if slug is not None:
+        news = get_object_or_404(News, slug=slug)
+    elif id is not None:
+        news = get_object_or_404(News, id=id)
+    else:
+        raise Http404("No News matches the given query.")
+    
     _logger.debug(f"Starting views/news for news.slug={slug} at {func_start_time:0.4f}")
 
-    news = get_object_or_404(News, slug=slug)
+    # news = get_object_or_404(News, slug=slug)
     # news = get_object_or_404(News, pk=news_id)
 
     max_extra_items = 4  # Maximum number of authors

--- a/website/views/news.py
+++ b/website/views/news.py
@@ -1,5 +1,5 @@
 from django.conf import settings # for access to settings variables, see https://docs.djangoproject.com/en/4.0/topics/settings/#using-settings-in-python-code
-from website.models import Banner, News
+from website.models import News
 
 import website.utils.ml_utils as ml_utils 
 from django.shortcuts import render, get_object_or_404
@@ -13,13 +13,13 @@ import logging
 _logger = logging.getLogger(__name__)
 
 # This method and the news functionality in general was written by Johnson Kuang
-def news(request, news_id):
+# def news(request, news_id):
+def news(request, slug):
     func_start_time = time.perf_counter()
-    _logger.debug(f"Starting views/news for news_id={news_id} at {func_start_time:0.4f}")
+    _logger.debug(f"Starting views/news for news.slug={slug} at {func_start_time:0.4f}")
 
-    all_banners = Banner.objects.filter(page=Banner.NEWSLISTING)
-    displayed_banners = ml_utils.choose_banners(all_banners)
-    news = get_object_or_404(News, pk=news_id)
+    news = get_object_or_404(News, slug=slug)
+    # news = get_object_or_404(News, pk=news_id)
 
     max_extra_items = 4  # Maximum number of authors
     all_author_news = news.author.news_set.order_by('-date')
@@ -40,15 +40,14 @@ def news(request, news_id):
                     ind_proj_news.append(item)
             project_news[project] = ind_proj_news[:max_extra_items]
 
-    context = {'banners': displayed_banners,
-               'news': news,
+    context = {'news': news,
                'author_news': author_news[:max_extra_items],
                'project_news': project_news,
                'navbar_white': True,
                'debug': settings.DEBUG}
     
     func_end_time = time.perf_counter()
-    _logger.debug(f"Rendered views/news for news_id={news_id} in {func_end_time - func_start_time:0.4f} seconds")
+    _logger.debug(f"Rendered views/news for news.slug={slug} in {func_end_time - func_start_time:0.4f} seconds")
     context['render_time'] = func_end_time - func_start_time
 
     # Render is a Django helper function. It combines a given template—in this case news.html—with


### PR DESCRIPTION
We can now visit news pages by their "slugs", which is a human-readable url from the title

So, rather than:
https://makeabilitylab-test.cs.washington.edu/news/58/

We can visit:
https://makeabilitylab-test.cs.washington.edu/news/professor-froehlich-receives-pactrans-outstanding-researcher-award/