### PR TITLE
External slides URL on Talk/Poster; drop slideshare_url (#1273)

### DIFF
--- a/website/admin/talk_admin.py
+++ b/website/admin/talk_admin.py
@@ -35,7 +35,7 @@ class TalkAdmin(ArtifactAdmin):
         (None,                      {'fields': ['title', 'authors', 'date']}),
         ('Files',                   {'fields': ['pdf_file', 'raw_file']}),
         ('Talk Venue Info',         {'fields': ['talk_type', 'forum_name', 'forum_url', 'location']}),
-        ('Links',                   {'fields': ['video', 'external_slides_url', 'slideshare_url']}),
+        ('Links',                   {'fields': ['video', 'external_slides_url']}),
         ('Project Info',            {'fields': ['projects', 'project_umbrellas']}),
         ('Keyword Info',            {'fields': ['keywords']}),
     ]

--- a/website/admin/talk_admin.py
+++ b/website/admin/talk_admin.py
@@ -35,7 +35,7 @@ class TalkAdmin(ArtifactAdmin):
         (None,                      {'fields': ['title', 'authors', 'date']}),
         ('Files',                   {'fields': ['pdf_file', 'raw_file']}),
         ('Talk Venue Info',         {'fields': ['talk_type', 'forum_name', 'forum_url', 'location']}),
-        ('Links',                   {'fields': ['video', 'slideshare_url']}),
+        ('Links',                   {'fields': ['video', 'external_slides_url', 'slideshare_url']}),
         ('Project Info',            {'fields': ['projects', 'project_umbrellas']}),
         ('Keyword Info',            {'fields': ['keywords']}),
     ]

--- a/website/models/artifact.py
+++ b/website/models/artifact.py
@@ -73,6 +73,32 @@ class Artifact(models.Model):
     
     get_first_author_last_name.short_description = 'First Author (Last Name)' # used in the admin display for column header
 
+    # Friendly labels for known raw_file extensions. Keys are lowercase,
+    # leading-dot extensions; values are the human-readable label shown
+    # next to the download link (e.g., on the public talks list).
+    RAW_FILE_LABELS = {
+        '.pptx': 'PPTX',
+        '.ppt': 'PPT',
+        '.key': 'Keynote',
+        '.ai': 'AI',
+        '.fig': 'Figma',
+    }
+
+    @property
+    def raw_file_label(self):
+        """
+        Human-readable label for the raw_file's format (e.g., "PPTX",
+        "Keynote", "AI"). Returns None when there is no raw_file. For
+        unknown extensions, returns the uppercased extension without the
+        leading dot so the link still has a sensible label.
+        """
+        if not self.raw_file:
+            return None
+        ext = os.path.splitext(self.raw_file.name)[1].lower()
+        if not ext:
+            return None
+        return self.RAW_FILE_LABELS.get(ext, ext.lstrip('.').upper())
+
     def __str__(self):
         if self.id and self.authors.exists():          
             return "{}, '{}', {} {}".format(self.get_first_author_last_name(), self.title, self.forum_name, self.date)

--- a/website/models/poster.py
+++ b/website/models/poster.py
@@ -1,9 +1,18 @@
 import os
+from django.db import models
 from website.models import Artifact
 
 class Poster(Artifact):
     UPLOAD_DIR = 'posters/'
     THUMBNAIL_DIR = os.path.join(UPLOAD_DIR, 'images/')
+
+    external_slides_url = models.URLField(blank=True, null=True)
+    external_slides_url.help_text = (
+        "Optional link to the source design (e.g., Figma, Canva, Illustrator "
+        "online). <b>Strongly recommended</b>: also upload an archival raw "
+        "file above (a .fig from Figma, .ai from Illustrator, etc.) &mdash; "
+        "cloud links break when students graduate or revoke access."
+    )
 
     def get_upload_dir(self, filename):
         return os.path.join(self.UPLOAD_DIR, filename)

--- a/website/models/talk.py
+++ b/website/models/talk.py
@@ -18,13 +18,10 @@ class TalkType(models.TextChoices):
 class Talk(Artifact):
     """
     The Talk class inherits from the Artifact class and represents a talk or presentation.
-    It includes fields for the talk type, slideshare URL, video, and upload directories.
+    It includes fields for the talk type, video, and upload directories.
     """
     UPLOAD_DIR = 'talks/'
     THUMBNAIL_DIR = os.path.join(UPLOAD_DIR, 'images/')
-
-    slideshare_url = models.URLField(blank=True, null=True)
-    slideshare_url.help_text = "Slideshare is no longer a popular way of sharing talks"
 
     external_slides_url = models.URLField(blank=True, null=True)
     external_slides_url.help_text = (

--- a/website/models/talk.py
+++ b/website/models/talk.py
@@ -26,6 +26,14 @@ class Talk(Artifact):
     slideshare_url = models.URLField(blank=True, null=True)
     slideshare_url.help_text = "Slideshare is no longer a popular way of sharing talks"
 
+    external_slides_url = models.URLField(blank=True, null=True)
+    external_slides_url.help_text = (
+        "Optional link to the source slide deck (e.g., Figma, Google Slides, "
+        "Canva). <b>Strongly recommended</b>: also upload an archival raw file "
+        "above (a .fig from Figma, a .pptx exported from Google Slides, etc.) "
+        "&mdash; cloud links break when students graduate or revoke access."
+    )
+
     # add in video field to address https://github.com/jonfroehlich/makeabilitylabwebsite/issues/539
     video = models.ForeignKey('Video', blank=True, null=True, on_delete=models.DO_NOTHING)
     video.help_text = "If there is a video recording of the talk, add it here."

--- a/website/templates/snippets/display_talk_snippet.html
+++ b/website/templates/snippets/display_talk_snippet.html
@@ -85,10 +85,10 @@ DEPENDENCIES:
       </a>
       
       {% if talk.raw_file %}
-      <a href="{{ MEDIA_URL }}{{ talk.raw_file }}" 
-         aria-label="Download PowerPoint for {{ talk.title }}">
-        <i class="fa-solid fa-file-powerpoint" aria-hidden="true"></i>
-        <span>PPTX</span>
+      <a href="{{ MEDIA_URL }}{{ talk.raw_file }}"
+         aria-label="Download {{ talk.raw_file_label }} slides for {{ talk.title }}">
+        <i class="fa-solid fa-file-arrow-down" aria-hidden="true"></i>
+        <span>{{ talk.raw_file_label }}</span>
       </a>
       {% endif %}
       

--- a/website/templates/snippets/display_talk_snippet.html
+++ b/website/templates/snippets/display_talk_snippet.html
@@ -91,6 +91,15 @@ DEPENDENCIES:
         <span>{{ talk.raw_file_label }}</span>
       </a>
       {% endif %}
+
+      {% if talk.external_slides_url %}
+      <a href="{{ talk.external_slides_url }}"
+         target="_blank" rel="noopener"
+         aria-label="View {{ talk.title }} slides in their original tool (opens in new tab)">
+        <i class="fa-solid fa-up-right-from-square" aria-hidden="true"></i>
+        <span>Source</span>
+      </a>
+      {% endif %}
       
       {% if talk.video %}
       <a href="{{ talk.video.video_url }}" 

--- a/website/templates/snippets/display_talk_snippet.html
+++ b/website/templates/snippets/display_talk_snippet.html
@@ -109,14 +109,6 @@ DEPENDENCIES:
       </a>
       {% endif %}
       
-      {% if talk.slideshare_url %}
-      <a href="{{ talk.slideshare_url }}" 
-         aria-label="View {{ talk.title }} on SlideShare">
-        <i class="fa-brands fa-slideshare" aria-hidden="true"></i>
-        <span>SlideShare</span>
-      </a>
-      {% endif %}
-      
       {% if talk.publication_set %}
       {% for pub in talk.publication_set.all %}
       <a href="{{ MEDIA_URL }}{{ pub.pdf_file }}" 

--- a/website/tests.py
+++ b/website/tests.py
@@ -890,6 +890,54 @@ class ArtifactFilenameUpdateCheckTests(SimpleTestCase):
             self.assertTrue(Artifact.do_filenames_need_updating(artifact))
 
 
+class ArtifactRawFileLabelTests(SimpleTestCase):
+    """
+    Regression tests for Artifact.raw_file_label (issue #1152).
+
+    The talk snippet previously hardcoded "PPTX" next to the raw_file
+    download link, mislabeling .key (Keynote) and any other format. The
+    label is derived from the file extension.
+    """
+
+    def _artifact_with_raw_file(self, name):
+        from website.models.artifact import Artifact
+        artifact = MagicMock(spec=Artifact)
+        artifact.raw_file = MagicMock() if name else None
+        if name:
+            artifact.raw_file.name = name
+        artifact.RAW_FILE_LABELS = Artifact.RAW_FILE_LABELS
+        return artifact
+
+    def _label(self, name):
+        from website.models.artifact import Artifact
+        return Artifact.raw_file_label.fget(self._artifact_with_raw_file(name))
+
+    def test_pptx_label(self):
+        self.assertEqual(self._label("talks/Doe2020Title.pptx"), "PPTX")
+
+    def test_keynote_label(self):
+        self.assertEqual(self._label("talks/Doe2020Title.key"), "Keynote")
+
+    def test_ai_label(self):
+        self.assertEqual(self._label("posters/Doe2020Title.ai"), "AI")
+
+    def test_figma_label(self):
+        self.assertEqual(self._label("talks/Doe2020Title.fig"), "Figma")
+
+    def test_extension_case_insensitive(self):
+        self.assertEqual(self._label("talks/Doe2020Title.PPTX"), "PPTX")
+        self.assertEqual(self._label("talks/Doe2020Title.Key"), "Keynote")
+
+    def test_unknown_extension_falls_back_to_uppercased_ext(self):
+        self.assertEqual(self._label("talks/Doe2020Title.odp"), "ODP")
+
+    def test_no_raw_file_returns_none(self):
+        self.assertIsNone(self._label(None))
+
+    def test_no_extension_returns_none(self):
+        self.assertIsNone(self._label("talks/Doe2020Title"))
+
+
 # ===========================================================================
 # Database-backed test infrastructure (#1267)
 # ===========================================================================

--- a/website/tests.py
+++ b/website/tests.py
@@ -1031,6 +1031,29 @@ class DatabaseTestCase(TestCase):
         )
         return Publication.objects.create(title=title, **kwargs)
 
+    def make_talk(self, title="A Test Talk", year=2024, **kwargs):
+        """
+        Create and return a Talk. Artifact.save() generates a thumbnail
+        from pdf_file (via ImageMagick) on every save, so we provide a
+        small valid PDF and let it run; tests that don't care about the
+        thumbnail just ignore it.
+        """
+        from datetime import date as _date
+        from website.models import Talk
+        from website.models.talk import TalkType
+        kwargs.setdefault("date", _date(year, 1, 1))
+        kwargs.setdefault("forum_name", "CHI")
+        kwargs.setdefault("talk_type", TalkType.CONFERENCE_TALK)
+        kwargs.setdefault(
+            "pdf_file",
+            SimpleUploadedFile(
+                f"{title.replace(' ', '_')}.pdf",
+                b"%PDF-1.4 test",
+                content_type="application/pdf",
+            ),
+        )
+        return Talk.objects.create(title=title, **kwargs)
+
     def make_news_item(self, title="Test News", author=None, **kwargs):
         """
         Create and return a News item. `author` is intentionally optional
@@ -1074,6 +1097,60 @@ class NewsItemNullAuthorViewTests(DatabaseTestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Authored News")
+
+
+# --- Talk snippet: external_slides_url rendering (#1273) -----------------
+
+
+class TalkExternalSlidesUrlTests(DatabaseTestCase):
+    """
+    Pins the rendering of Talk.external_slides_url in
+    snippets/display_talk_snippet.html — the "Source" link should appear
+    only when the URL is set. Also pins that Poster persists the field
+    (no display surface for posters yet, but the column must exist).
+    """
+
+    def _render_talk_snippet(self, talk):
+        from django.template.loader import render_to_string
+        return render_to_string(
+            "snippets/display_talk_snippet.html",
+            {"talk": talk, "MEDIA_URL": "/media/"},
+        )
+
+    def test_source_link_renders_when_external_slides_url_set(self):
+        talk = self.make_talk(
+            title="Figma Talk",
+            external_slides_url="https://www.figma.com/file/abc123/slides",
+        )
+        html = self._render_talk_snippet(talk)
+        self.assertIn("https://www.figma.com/file/abc123/slides", html)
+        self.assertIn("fa-up-right-from-square", html)
+        # opens-in-new-tab affordance must be present for accessibility
+        self.assertIn('target="_blank"', html)
+        self.assertIn('rel="noopener"', html)
+
+    def test_source_link_absent_when_external_slides_url_blank(self):
+        talk = self.make_talk(title="No-Source Talk")
+        html = self._render_talk_snippet(talk)
+        self.assertNotIn("fa-up-right-from-square", html)
+
+    def test_poster_external_slides_url_round_trips(self):
+        """Schema pin: Poster.external_slides_url must persist to the DB."""
+        from website.models import Poster
+        poster = Poster.objects.create(
+            title="A Test Poster",
+            external_slides_url="https://www.figma.com/file/xyz/poster",
+            pdf_file=SimpleUploadedFile(
+                "test_poster.pdf",
+                b"%PDF-1.4 test",
+                content_type="application/pdf",
+            ),
+        )
+        reloaded = Poster.objects.get(pk=poster.pk)
+        self.assertEqual(
+            reloaded.external_slides_url,
+            "https://www.figma.com/file/xyz/poster",
+        )
 
 
 # --- Query-count: /publications/ prefetch_related (regression for d4f6d65) -


### PR DESCRIPTION
## Summary

- Adds optional `external_slides_url` (URLField) to `Talk` and `Poster` so students can record a link to the source slide deck in any cloud tool (Figma, Google Slides, Canva, etc.) instead of being tied to a specific platform.
- Admin help_text on each field strongly recommends *also* uploading an archival raw file (`.fig`, `.pptx`, etc.) since cloud links break when students graduate or revoke access.
- Talk snippet renders the link as a "Source" download-row item with a format-neutral external-link icon (`fa-up-right-from-square`), `target="_blank"`, and an aria-label that announces the new-tab behavior.
- Drops `slideshare_url` entirely. SlideShare is no longer a relevant platform; the new generic field covers anything you'd link there. ~14 existing `slideshare_url` values on prod will be lost — intentional (those are archival pointers to an inactive account).

Closes #1273. Follow-up to #1152 (which added `.fig` to the raw-file label map and ships in this same diff path).

## Test plan

- [x] Unit + integration tests pass locally (`python manage.py test website` — 74 tests, all green)
- [x] New `TalkExternalSlidesUrlTests` cover: link rendered when URL set, link absent when blank, Poster column round-trips
- [x] Manually verified new "Source" link renders on `/member/jonfroehlich/` in the local dev container
- [x] Pa11y scan run; the new link's only flagged issue is the same pre-existing `.talk-download-links a span` color-contrast problem already affecting `<span>PDF</span>` / `<span>PPTX</span>` — consistent with existing pattern, separate concern
- [ ] **Before/after screenshots needed (per CONTRIBUTING)** — the new "Source" link only renders when `external_slides_url` is set, so capture a member or project page with a talk that has the URL populated (set via admin)
- [ ] Verify on test server after merge: the auto-generated `RemoveField` migration drops `slideshare_url` cleanly and the 14 slideshare URLs are gone as expected

## Notes

- Migration file (`0034_remove_talk_slideshare_url.py`, `0033_…external_slides_url.py`) is gitignored per project convention; container regenerates on startup.
- Poster has no public display surface for raw_file today; the new field exists on the model and is admin-editable, with a round-trip test pinning the column. A poster snippet is a separate concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)