### PR TITLE
Add read-only Data Health admin dashboard + checks (#1276)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,16 @@ A superuser is required to use `/admin` and add content; create one with `python
 - Bump `ML_WEBSITE_VERSION` and `ML_WEBSITE_VERSION_DESCRIPTION` in `makeabilitylab/settings.py` when cutting a release.
 - Build logs: `<host>/logs/buildlog.txt`. Application logs: `<host>/logs/debug.log`. See `docs/DEPLOYMENT.md` for SSH paths on `recycle.cs.washington.edu`.
 
+### Server access model (important — shapes how anything ships to prod/test)
+
+The maintainer does **not** have shell or admin access to the test or production servers. UW CSE IT (Jason Howe) owns and configured both; Apache/web-server and file-permission changes go through them, and much of the deployed tree is `apache:makelab`-owned. The only available controls and visibility are:
+
+- **Deploys are push-only.** Push to `master` → test; push a SemVer tag → prod. There is **no way to run `docker` or `manage.py` directly** on either server.
+- **SSH is read-mostly and limited to one jump host.** The maintainer can SSH to `recycle.cs.washington.edu` and read files on the shared CSE filesystem under `/cse/web/research/makelab/` (logs, the `media/` dir, `secret/config.ini`). There is **no SSH access to the host that runs the Docker stack** and no passwordless sudo.
+- **The database is not reachable directly.** Prod Postgres runs as the `db` Docker container, bound to the Docker host's **loopback only**, so there is no tunnel/network path to it from a laptop or from `recycle`. (Credentials are moot anyway — see below.)
+- **Therefore, any operation against prod/test data must run *inside* the container.** Ship it as a management command wired into `docker-entrypoint.sh` (the established one-shot pattern) and verify via the logs. For one-off offline analysis, request a DB snapshot from CSE IT rather than trying to connect remotely.
+- **Never write personal or sensitive data to web-served paths** (`media/`, `static/`, `logs/`) — everything under them is publicly downloadable. (A stale public `dumped_data.json` was exactly this mistake.)
+
 ## Architecture
 
 ### Project layout
@@ -88,9 +98,11 @@ Custom admin organization lives in `website/admin/admin_site.py` (`MakeabilityLa
 
 ### Settings, config, and environment
 
-- `makeabilitylab/settings.py` reads `config.ini` at project root for production secrets and DB credentials. `config.ini` is **not** committed — production mounts it as a Docker volume.
+- **Compose files per environment:** the servers run `docker-compose.yml` (test *and* prod — `makeabilitylabwebsite/rebuildanddeploy.sh` runs `docker compose up` with no `-f`, so it always picks the default `docker-compose.yml`; it only varies per-host env vars). Local dev runs `docker-compose-local-dev.yml` (passed explicitly with `-f`). `docker-compose-local-dev.yml` is **never** used on the servers.
+- **Per-host wiring** (set by `rebuildanddeploy.sh`): test host `docker-test2` → `DJANGO_ENV=TEST`, mounts `secret/config-test.ini` + `www-test/` media; prod host `grabthar` → `DJANGO_ENV=PROD`, mounts `secret/config.ini` + `www/` media.
+- `makeabilitylab/settings.py` reads `config.ini` (mounted at the project root, **not** committed) for `SECRET_KEY`, `DEBUG`, and `ALLOWED_HOSTS`.
+- **Prod/test `config.ini` has only a `[Django]` section — no `[Postgres]` section.** Per `settings.py`, a missing `[Postgres]` section means Django uses the fallback `DATABASES` default (`HOST='db'`) — i.e. the dockerized `db` service of the active compose file. A `[Postgres]` section, if added, would override it. So the DB is the in-stack `db` container in **every** environment (no external Postgres); on the servers that's the `db` service in `docker-compose.yml`.
 - `DEBUG` resolution order: `DJANGO_ENV=PROD` forces False → `config.ini [Django] DEBUG` → `DJANGO_ENV=DEBUG` forces True → default False.
-- Without a `[Postgres]` section in `config.ini`, Django falls back to the dockerized dev DB (`db:5432`, user `admin`, pw `password`, db `makeability`) defined in `docker-compose-local-dev.yml`.
 - `TIME_ZONE = 'America/Los_Angeles'`. `ML_WEBSITE_VERSION` in settings is shown in the admin header and used in release tagging.
 
 ### Container startup side effects (`docker-entrypoint.sh`)

--- a/website/admin/__init__.py
+++ b/website/admin/__init__.py
@@ -68,3 +68,8 @@ from . import (
     talk_admin,
     video_admin,
 )
+
+# Import the data_health package so its @register_check decorators run and
+# populate the Data Health dashboard registry (wired into the admin URLconf
+# by MakeabilityLabAdminSite.get_urls()).
+from website.admin import data_health  # noqa: F401

--- a/website/admin/admin_site.py
+++ b/website/admin/admin_site.py
@@ -23,8 +23,9 @@ Usage:
 from django.contrib import admin
 from django.contrib.admin.apps import AdminConfig
 from django.conf import settings
-from django.contrib.auth.models import Group, User     
-from django.contrib.auth.admin import GroupAdmin, UserAdmin 
+from django.contrib.auth.models import Group, User
+from django.contrib.auth.admin import GroupAdmin, UserAdmin
+from django.urls import path
 
 
 class MakeabilityLabAdminSite(admin.AdminSite):
@@ -77,6 +78,30 @@ class MakeabilityLabAdminSite(admin.AdminSite):
         ),
     ]
     
+    def get_urls(self):
+        """
+        Prepend the read-only Data Health pages to the admin URLconf.
+
+        Each view is wrapped in ``self.admin_view`` (enforces staff + login,
+        adds the admin context) and additionally checks ``is_superuser``
+        inside the view because the checks expose personal data. The
+        data_health views are imported lazily to avoid import-time cycles.
+        """
+        from website.admin.data_health import views as data_health_views
+
+        custom_urls = [
+            path('data-health/',
+                 self.admin_view(data_health_views.dashboard),
+                 name='data_health_dashboard'),
+            path('data-health/<slug:check_slug>/export.csv',
+                 self.admin_view(data_health_views.export_csv),
+                 name='data_health_export'),
+            path('data-health/<slug:check_slug>/',
+                 self.admin_view(data_health_views.detail),
+                 name='data_health_detail'),
+        ]
+        return custom_urls + super().get_urls()
+
     def get_app_list(self, request, app_label=None):
         """
         Return a reorganized list of apps/models for the admin index.

--- a/website/admin/data_health/__init__.py
+++ b/website/admin/data_health/__init__.py
@@ -1,0 +1,12 @@
+"""
+Read-only "Data Health" admin checks package.
+
+Importing this package imports every check module (via ``checks``), whose
+``@register_check`` decorators populate :data:`REGISTRY`. The package is
+imported from ``website/admin/__init__.py`` so the checks are registered at
+startup, and wired into the admin URLconf by
+``MakeabilityLabAdminSite.get_urls()``.
+"""
+
+from website.admin.data_health import checks  # noqa: F401  (populates REGISTRY)
+from website.admin.data_health.registry import REGISTRY  # noqa: F401

--- a/website/admin/data_health/checks/__init__.py
+++ b/website/admin/data_health/checks/__init__.py
@@ -1,0 +1,14 @@
+"""Import every check module so its ``@register_check`` decorator runs.
+
+The import order here is the order checks appear on the dashboard.
+"""
+
+from website.admin.data_health.checks import (  # noqa: F401
+    duplicate_people,
+    url_name_collisions,
+    media_integrity,
+    publication_quality,
+    project_health,
+    position_integrity,
+    news_health,
+)

--- a/website/admin/data_health/checks/duplicate_people.py
+++ b/website/admin/data_health/checks/duplicate_people.py
@@ -1,0 +1,111 @@
+"""
+Data-health check: clusters of Person records that share a normalized name.
+
+These are the candidates for the issue #1275 dedup work — either *true
+duplicates* (one human, multiple rows) to merge, or genuine *namesakes* to
+keep separate. One row is emitted per person in any multi-person name
+cluster, with relation counts to support the merge / keep / delete decision
+(``total_refs == 0`` means a safe-to-delete shell). Strictly read-only.
+"""
+
+from collections import defaultdict
+
+from website.admin.data_health.registry import HealthCheck, register_check
+from website.models import Person, Position
+from website.utils.name_utils import normalize_person_name, is_default_person_image
+
+
+def _reverse_count(person, attr):
+    """Count related objects via a reverse manager, or 0 if it doesn't exist."""
+    manager = getattr(person, attr, None)
+    return manager.count() if manager is not None else 0
+
+
+@register_check
+class DuplicatePeopleCheck(HealthCheck):
+    slug = 'duplicate-people'
+    title = 'Duplicate people (same normalized name)'
+    description = (
+        'Person records that share an accent-folded name key — candidates for '
+        'merge or namesake review (issue #1275). total_refs == 0 is a safe-to-'
+        'delete shell.'
+    )
+    group = 'People'
+    columns = [
+        'cluster_key', 'id', 'first_name', 'middle_name', 'last_name',
+        'url_name', 'email', 'personal_website', 'github', 'linkedin',
+        'pub_count', 'talk_count', 'poster_count', 'video_count',
+        'position_count', 'projectrole_count', 'news_authored_count',
+        'advisor_count', 'co_advisor_count', 'grad_mentor_count',
+        'total_refs', 'has_real_image',
+        'earliest_position_date', 'latest_position_date',
+    ]
+
+    def get_rows(self):
+        # Group all people by their normalized name key.
+        clusters = defaultdict(list)
+        for p in Person.objects.all().prefetch_related('position_set'):
+            clusters[normalize_person_name(p.first_name, p.last_name)].append(p)
+
+        rows = []
+        for key, members in clusters.items():
+            if len(members) < 2:
+                continue  # only multi-person clusters are dups / namesakes
+            for p in members:
+                rows.append(self._row(key, p))
+
+        # Stable, scannable ordering: by cluster key then id.
+        rows.sort(key=lambda r: (r['cluster_key'], r['id']))
+        return rows
+
+    def _row(self, key, p):
+        positions = list(p.position_set.all())  # prefetched; no extra query
+
+        pub_count = _reverse_count(p, 'publication_set')
+        talk_count = _reverse_count(p, 'talk_set')
+        poster_count = _reverse_count(p, 'poster_set')
+        # Video has no authors relation today, so this is always 0 — kept for
+        # parity with the #1275 export spec and future-proofing.
+        video_count = _reverse_count(p, 'video_set')
+        position_count = len(positions)
+        projectrole_count = _reverse_count(p, 'projectrole_set')
+        news_count = _reverse_count(p, 'authored_news')
+        # Advisor self-references are easy to miss on merge — count them.
+        advisor_count = Position.objects.filter(advisor=p).count()
+        co_advisor_count = Position.objects.filter(co_advisor=p).count()
+        grad_mentor_count = Position.objects.filter(grad_mentor=p).count()
+
+        total_refs = (pub_count + talk_count + poster_count + video_count
+                      + position_count + projectrole_count + news_count
+                      + advisor_count + co_advisor_count + grad_mentor_count)
+
+        start_dates = [pos.start_date for pos in positions if pos.start_date]
+        end_dates = [pos.end_date for pos in positions if pos.end_date]
+
+        return {
+            'cluster_key': key,
+            'id': p.pk,
+            'first_name': p.first_name,
+            'middle_name': p.middle_name or '',
+            'last_name': p.last_name,
+            'url_name': p.url_name,
+            'email': p.email or '',
+            'personal_website': p.personal_website or '',
+            'github': p.github or '',
+            'linkedin': p.linkedin or '',
+            'pub_count': pub_count,
+            'talk_count': talk_count,
+            'poster_count': poster_count,
+            'video_count': video_count,
+            'position_count': position_count,
+            'projectrole_count': projectrole_count,
+            'news_authored_count': news_count,
+            'advisor_count': advisor_count,
+            'co_advisor_count': co_advisor_count,
+            'grad_mentor_count': grad_mentor_count,
+            'total_refs': total_refs,
+            # Best-effort (see is_default_person_image caveat for headshots).
+            'has_real_image': not is_default_person_image(p.image),
+            'earliest_position_date': min(start_dates).isoformat() if start_dates else '',
+            'latest_position_date': max(end_dates).isoformat() if end_dates else '',
+        }

--- a/website/admin/data_health/checks/media_integrity.py
+++ b/website/admin/data_health/checks/media_integrity.py
@@ -1,0 +1,111 @@
+"""
+Data-health check: artifact file references vs. files on disk.
+
+Surfaces two problems for Publication / Talk / Poster:
+  * **missing-file** — a ``pdf_file`` / ``raw_file`` / ``thumbnail`` field is
+    set but the file no longer exists on disk.
+  * **orphan-file** — a file sits under an upload/thumbnail dir with no DB
+    row pointing at it (what ``delete_unused_files`` would remove).
+
+The orphan-file scan mirrors the glob+filter logic in
+``website/management/commands/delete_unused_files.py`` (excluding the
+easy-thumbnails ``_detail`` variants). Read-only — it never deletes.
+"""
+
+import glob
+import os
+
+from django.conf import settings
+
+from website.admin.data_health.registry import HealthCheck, register_check
+from website.models import Poster, Publication, Talk
+
+# (model, file-field name, extensions to scan for orphans in UPLOAD_DIR)
+_FILE_FIELDS = [
+    ('pdf_file', ['*.pdf']),
+    ('raw_file', ['*.pptx', '*.key', '*.ai', '*.fig']),
+]
+
+
+def _safe_path(file_field):
+    """Return a FileField's filesystem path, or None if unavailable."""
+    try:
+        return file_field.path
+    except (ValueError, NotImplementedError):
+        return None
+
+
+@register_check
+class MediaIntegrityCheck(HealthCheck):
+    slug = 'media-integrity'
+    title = 'Media / file integrity'
+    description = (
+        'Artifact file fields pointing at missing files, plus orphaned files '
+        'on disk with no DB reference (what delete_unused_files would remove).'
+    )
+    group = 'Artifacts'
+    columns = ['type', 'id', 'title', 'field', 'path', 'status']
+
+    def get_rows(self):
+        rows = []
+        for model in (Publication, Talk, Poster):
+            rows.extend(self._missing_files(model))
+            rows.extend(self._orphan_files(model))
+        return rows
+
+    def _missing_files(self, model):
+        """DB rows whose file field is set but the file is gone from disk."""
+        rows = []
+        for obj in model.objects.all():
+            for field_name in ('pdf_file', 'raw_file', 'thumbnail'):
+                field = getattr(obj, field_name, None)
+                if not field:
+                    continue
+                path = _safe_path(field)
+                if path and not os.path.exists(path):
+                    rows.append({
+                        'type': model.__name__,
+                        'id': obj.pk,
+                        'title': obj.title or '',
+                        'field': field_name,
+                        'path': field.name,
+                        'status': 'missing-file',
+                    })
+        return rows
+
+    def _orphan_files(self, model):
+        """Files on disk under the model's dirs with no DB reference."""
+        rows = []
+
+        # Build the set of basenames the DB references for this model.
+        referenced = set()
+        for obj in model.objects.all():
+            for field_name in ('pdf_file', 'raw_file', 'thumbnail'):
+                field = getattr(obj, field_name, None)
+                if field and field.name:
+                    referenced.add(os.path.basename(field.name))
+
+        # Scan UPLOAD_DIR for pdf/raw files and THUMBNAIL_DIR for jpgs.
+        scan = []
+        upload_dir = os.path.join(settings.MEDIA_ROOT, model.UPLOAD_DIR)
+        for patterns in (exts for _, exts in _FILE_FIELDS):
+            for pattern in patterns:
+                scan.extend(glob.glob(os.path.join(upload_dir, pattern)))
+        thumb_dir = os.path.join(settings.MEDIA_ROOT, model.THUMBNAIL_DIR)
+        scan.extend(glob.glob(os.path.join(thumb_dir, '*.jpg')))
+
+        for full_path in scan:
+            basename = os.path.basename(full_path)
+            if '_detail' in basename:
+                continue  # easy-thumbnails variant; handled by its own cleanup
+            if basename in referenced:
+                continue
+            rows.append({
+                'type': model.__name__,
+                'id': '',
+                'title': '',
+                'field': '',
+                'path': full_path,
+                'status': 'orphan-file',
+            })
+        return rows

--- a/website/admin/data_health/checks/news_health.py
+++ b/website/admin/data_health/checks/news_health.py
@@ -1,0 +1,37 @@
+"""
+Data-health check: News items missing a slug or an author.
+
+A blank/null ``slug`` breaks the canonical ``/news/<slug>/`` URL (the
+``generate_slugs_for_old_news_items`` command backfills these), and a null
+``author`` leaves the item unattributed. Read-only.
+"""
+
+from django.db.models import Q
+
+from website.admin.data_health.registry import HealthCheck, register_check
+from website.models import News
+
+
+@register_check
+class NewsHealthCheck(HealthCheck):
+    slug = 'news-health'
+    title = 'News health'
+    description = "News items missing a slug or an author."
+    group = 'People'
+    columns = ['id', 'title', 'date', 'missing_slug', 'has_author']
+
+    def get_rows(self):
+        flagged = News.objects.filter(
+            Q(slug__isnull=True) | Q(slug='') | Q(author__isnull=True)
+        ).order_by('-date')
+
+        rows = []
+        for item in flagged:
+            rows.append({
+                'id': item.pk,
+                'title': item.title,
+                'date': item.date.isoformat() if item.date else '',
+                'missing_slug': not bool(item.slug),
+                'has_author': item.author_id is not None,
+            })
+        return rows

--- a/website/admin/data_health/checks/position_integrity.py
+++ b/website/admin/data_health/checks/position_integrity.py
@@ -1,0 +1,62 @@
+"""
+Data-health check: Position records and the advisor/mentor graph.
+
+Surfaces people with no Position at all, positions whose dates are inverted
+(``start_date > end_date``), and self-referential advisor links
+(``advisor`` / ``co_advisor`` / ``grad_mentor`` pointing at the position's own
+person). The advisor self-refs overlap the issue #1275 merge surface, so this
+doubles as a pre-merge sanity check. Read-only.
+"""
+
+from website.admin.data_health.registry import HealthCheck, register_check
+from website.models import Person, Position
+
+
+@register_check
+class PositionIntegrityCheck(HealthCheck):
+    slug = 'position-integrity'
+    title = 'Position & advisor-graph integrity'
+    description = (
+        'People with no position, positions with start_date after end_date, '
+        'and advisor/co_advisor/grad_mentor links that point at the person '
+        'themselves.'
+    )
+    group = 'People'
+    columns = ['person_id', 'name', 'issue', 'detail']
+
+    def get_rows(self):
+        rows = []
+
+        # People with no Position at all.
+        for person in Person.objects.filter(position__isnull=True):
+            rows.append({
+                'person_id': person.pk,
+                'name': person.get_full_name(),
+                'issue': 'no position',
+                'detail': '',
+            })
+
+        # Per-position anomalies.
+        positions = Position.objects.select_related(
+            'person', 'advisor', 'co_advisor', 'grad_mentor')
+        for pos in positions:
+            person = pos.person
+            if pos.start_date and pos.end_date and pos.start_date > pos.end_date:
+                rows.append({
+                    'person_id': person.pk,
+                    'name': person.get_full_name(),
+                    'issue': 'inverted dates',
+                    'detail': f'start {pos.start_date} > end {pos.end_date} (position {pos.pk})',
+                })
+            for field in ('advisor', 'co_advisor', 'grad_mentor'):
+                related = getattr(pos, field)
+                if related is not None and related.pk == person.pk:
+                    rows.append({
+                        'person_id': person.pk,
+                        'name': person.get_full_name(),
+                        'issue': f'self-{field}',
+                        'detail': f'position {pos.pk} lists the person as their own {field}',
+                    })
+
+        rows.sort(key=lambda r: (r['name'].lower(), r['issue']))
+        return rows

--- a/website/admin/data_health/checks/project_health.py
+++ b/website/admin/data_health/checks/project_health.py
@@ -1,0 +1,69 @@
+"""
+Data-health check: projects that are incomplete or invisible on the site.
+
+The public member/gallery views only show a project when it has a thumbnail
+(``gallery_image``) and a publication (see ``Project.can_show_online`` and the
+member-view filter), so a project missing either is effectively invisible.
+Also flags projects with no active members or no umbrella. Read-only.
+"""
+
+from datetime import date
+
+from website.admin.data_health.registry import HealthCheck, register_check
+from website.models import Project
+
+
+@register_check
+class ProjectHealthCheck(HealthCheck):
+    slug = 'project-health'
+    title = 'Project health'
+    description = (
+        'Projects missing a thumbnail or publication (invisible on the public '
+        'site), with no currently-active members, or with no umbrella.'
+    )
+    group = 'Projects'
+    columns = [
+        'id', 'name', 'short_name', 'has_thumbnail', 'has_publication',
+        'active_member_count', 'has_umbrella', 'issues',
+    ]
+
+    def get_rows(self):
+        today = date.today()
+        rows = []
+        for project in Project.objects.all().prefetch_related('projectrole_set'):
+            has_thumbnail = bool(project.gallery_image)
+            has_publication = project.has_publication()
+
+            active_member_count = sum(
+                1 for role in project.projectrole_set.all()
+                if role.start_date and role.start_date <= today
+                and (role.end_date is None or role.end_date >= today)
+            )
+            has_umbrella = project.project_umbrellas.exists()
+
+            issues = []
+            if not has_thumbnail:
+                issues.append('no thumbnail')
+            if not has_publication:
+                issues.append('no publication')
+            if active_member_count == 0:
+                issues.append('no active members')
+            if not has_umbrella:
+                issues.append('no umbrella')
+
+            if not issues:
+                continue
+
+            rows.append({
+                'id': project.pk,
+                'name': project.name,
+                'short_name': project.short_name,
+                'has_thumbnail': has_thumbnail,
+                'has_publication': has_publication,
+                'active_member_count': active_member_count,
+                'has_umbrella': has_umbrella,
+                'issues': ', '.join(issues),
+            })
+
+        rows.sort(key=lambda r: r['name'].lower())
+        return rows

--- a/website/admin/data_health/checks/publication_quality.py
+++ b/website/admin/data_health/checks/publication_quality.py
@@ -1,0 +1,69 @@
+"""
+Data-health check: Publication metadata completeness + duplicate titles.
+
+Publications are the central artifact, so missing core metadata (PDF, date,
+venue, thumbnail) degrades the public site and citations. Also flags
+publications that share a normalized title (possible duplicate entry).
+Read-only.
+"""
+
+from collections import defaultdict
+
+from website.admin.data_health.registry import HealthCheck, register_check
+from website.models import Publication
+
+
+def _normalize_title(title):
+    """Lowercased, alphanumeric-only title key for duplicate detection."""
+    return ''.join(ch for ch in (title or '').lower() if ch.isalnum())
+
+
+@register_check
+class PublicationQualityCheck(HealthCheck):
+    slug = 'publication-quality'
+    title = 'Publication data quality'
+    description = (
+        'Publications missing a PDF, date, venue (forum_name), or thumbnail, '
+        'and publications that share a normalized title (possible duplicates).'
+    )
+    group = 'Artifacts'
+    columns = ['id', 'title', 'date', 'missing_fields', 'dup_title']
+
+    def get_rows(self):
+        pubs = list(Publication.objects.all())
+
+        # Find normalized titles shared by more than one publication.
+        title_counts = defaultdict(int)
+        for pub in pubs:
+            key = _normalize_title(pub.title)
+            if key:
+                title_counts[key] += 1
+
+        rows = []
+        for pub in pubs:
+            missing = []
+            if not pub.pdf_file:
+                missing.append('pdf_file')
+            if not pub.date:
+                missing.append('date')
+            if not pub.forum_name:
+                missing.append('forum_name')
+            if not pub.thumbnail:
+                missing.append('thumbnail')
+
+            key = _normalize_title(pub.title)
+            dup_title = bool(key) and title_counts[key] > 1
+
+            if not missing and not dup_title:
+                continue  # this publication is healthy
+
+            rows.append({
+                'id': pub.pk,
+                'title': pub.title or '',
+                'date': pub.date.isoformat() if pub.date else '',
+                'missing_fields': ', '.join(missing),
+                'dup_title': dup_title,
+            })
+
+        rows.sort(key=lambda r: (not r['dup_title'], r['title']))
+        return rows

--- a/website/admin/data_health/checks/url_name_collisions.py
+++ b/website/admin/data_health/checks/url_name_collisions.py
@@ -1,0 +1,47 @@
+"""
+Data-health check: Person.url_name collisions and unresolved placeholders.
+
+Two members sharing a ``url_name`` cause ``MultipleObjectsReturned`` ->
+HTTP 500 on ``/member/<url_name>/`` (issue #1206). Rows still holding the
+model default ``'placeholder'`` were created/never re-saved before the
+collision loop landed. Strictly read-only.
+"""
+
+from collections import defaultdict
+
+from website.admin.data_health.registry import HealthCheck, register_check
+from website.models import Person
+
+
+@register_check
+class UrlNameCollisionsCheck(HealthCheck):
+    slug = 'url-name-collisions'
+    title = 'url_name collisions & placeholders'
+    description = (
+        "Person rows sharing a url_name (the live /member/ 500 source, issue "
+        "#1206) or still set to the default 'placeholder'."
+    )
+    group = 'People'
+    columns = ['url_name', 'count', 'person_ids', 'names']
+
+    def get_rows(self):
+        by_url_name = defaultdict(list)
+        for p in Person.objects.all():
+            by_url_name[p.url_name].append(p)
+
+        rows = []
+        for url_name, people in by_url_name.items():
+            is_collision = len(people) > 1
+            is_placeholder = url_name == 'placeholder'
+            if not (is_collision or is_placeholder):
+                continue
+            rows.append({
+                'url_name': url_name,
+                'count': len(people),
+                'person_ids': ', '.join(str(p.pk) for p in sorted(people, key=lambda x: x.pk)),
+                'names': '; '.join(p.get_full_name() for p in people),
+            })
+
+        # Worst offenders first, then alphabetical.
+        rows.sort(key=lambda r: (-r['count'], r['url_name']))
+        return rows

--- a/website/admin/data_health/registry.py
+++ b/website/admin/data_health/registry.py
@@ -1,0 +1,85 @@
+"""
+Lightweight registry + base class for read-only "Data Health" admin checks.
+
+Each check subclasses :class:`HealthCheck` and is registered with
+``@register_check``. The admin dashboard (website/admin/data_health/views.py)
+iterates :data:`REGISTRY` to show a flagged-row count per check; each check
+renders a detail table and a CSV download generated on the fly.
+
+Checks MUST be strictly read-only — never call ``.save()`` or mutate the DB.
+"""
+
+import csv
+import io
+
+from django.http import HttpResponse
+from django.utils import timezone
+
+
+class HealthCheck:
+    """
+    Base class for a single read-only data-health check.
+
+    Subclasses set the class attributes below and implement :meth:`get_rows`,
+    returning a list of dicts keyed by the entries in :attr:`columns`.
+    """
+
+    #: URL-safe identifier, e.g. ``"duplicate-people"``.
+    slug = ''
+    #: Human-readable title shown on the dashboard and detail page.
+    title = ''
+    #: One-line description of what the check surfaces.
+    description = ''
+    #: Dashboard grouping, e.g. ``"People"`` / ``"Artifacts"`` / ``"Projects"``.
+    group = 'Other'
+    #: Ordered column keys; used as table headers and the CSV header row.
+    columns = []
+
+    def get_rows(self):
+        """Return a list of row dicts (read-only). Override in subclasses."""
+        raise NotImplementedError
+
+    def count(self):
+        """Number of flagged rows. Override for a cheaper count if available."""
+        return len(self.get_rows())
+
+
+# Ordered list of registered checks, plus a slug -> instance lookup.
+REGISTRY = []
+_REGISTRY_BY_SLUG = {}
+
+
+def register_check(check_cls):
+    """Class decorator: instantiate a HealthCheck subclass and register it."""
+    instance = check_cls()
+    if not instance.slug:
+        raise ValueError(f"{check_cls.__name__} must define a non-empty slug")
+    if instance.slug in _REGISTRY_BY_SLUG:
+        raise ValueError(f"Duplicate data-health check slug: {instance.slug}")
+    REGISTRY.append(instance)
+    _REGISTRY_BY_SLUG[instance.slug] = instance
+    return check_cls
+
+
+def get_check(slug):
+    """Return the registered check instance for ``slug``, or None."""
+    return _REGISTRY_BY_SLUG.get(slug)
+
+
+def rows_to_csv_response(check):
+    """
+    Render ``check``'s rows as a downloadable CSV ``HttpResponse``.
+
+    The CSV is built in memory and streamed through the (authenticated)
+    response, so it never touches a web-served path on disk.
+    """
+    buffer = io.StringIO()
+    writer = csv.DictWriter(buffer, fieldnames=check.columns, extrasaction='ignore')
+    writer.writeheader()
+    for row in check.get_rows():
+        writer.writerow(row)
+
+    today = timezone.now().date().isoformat()
+    response = HttpResponse(buffer.getvalue(), content_type='text/csv')
+    response['Content-Disposition'] = f'attachment; filename="{check.slug}-{today}.csv"'
+    return response

--- a/website/admin/data_health/views.py
+++ b/website/admin/data_health/views.py
@@ -1,0 +1,72 @@
+"""
+Read-only, superuser-gated admin views for the Data Health dashboard.
+
+Wired into the admin URLconf by ``MakeabilityLabAdminSite.get_urls()``
+(website/admin/admin_site.py). ``self.admin_view`` already enforces staff +
+login; these views additionally require ``is_superuser`` because the
+underlying checks expose personal data (e.g. member emails).
+"""
+
+from django.contrib import admin
+from django.core.exceptions import PermissionDenied
+from django.http import Http404
+from django.shortcuts import render
+
+from website.admin.data_health.registry import REGISTRY, get_check, rows_to_csv_response
+
+
+def _require_superuser(request):
+    """Raise PermissionDenied unless the logged-in admin is a superuser."""
+    if not request.user.is_superuser:
+        raise PermissionDenied("Data Health pages require superuser access.")
+
+
+def _admin_context(request, title):
+    """Base admin chrome context (site header, nav, etc.) plus a page title."""
+    context = admin.site.each_context(request)
+    context['title'] = title
+    return context
+
+
+def dashboard(request):
+    """Hub page: list every registered check with its flagged-row count."""
+    _require_superuser(request)
+    checks = [
+        {
+            'slug': c.slug,
+            'title': c.title,
+            'description': c.description,
+            'group': c.group,
+            'count': c.count(),
+        }
+        for c in REGISTRY
+    ]
+    context = _admin_context(request, title='Data Health')
+    context['checks'] = checks
+    return render(request, 'admin/data_health/dashboard.html', context)
+
+
+def detail(request, check_slug):
+    """Detail page: full table for one check plus a CSV-download link."""
+    _require_superuser(request)
+    check = get_check(check_slug)
+    if check is None:
+        raise Http404("Unknown data-health check.")
+    # Flatten dict rows into cell lists aligned to the column order so the
+    # template can render them without a dynamic dict-lookup filter.
+    columns = check.columns
+    rows = [[row.get(col, '') for col in columns] for row in check.get_rows()]
+    context = _admin_context(request, title=check.title)
+    context['check'] = check
+    context['columns'] = columns
+    context['rows'] = rows
+    return render(request, 'admin/data_health/detail.html', context)
+
+
+def export_csv(request, check_slug):
+    """Stream one check's rows as a CSV download (generated on the fly)."""
+    _require_superuser(request)
+    check = get_check(check_slug)
+    if check is None:
+        raise Http404("Unknown data-health check.")
+    return rows_to_csv_response(check)

--- a/website/templates/admin/data_health/dashboard.html
+++ b/website/templates/admin/data_health/dashboard.html
@@ -1,0 +1,65 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block breadcrumbs %}
+  <div class="breadcrumbs">
+    <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
+    &rsaquo; {% translate 'Data Health' %}
+  </div>
+{% endblock %}
+
+{% block content %}
+  <p class="dh-intro">
+    Read-only data-quality checks. Open a check to see the full table and
+    download a CSV. These pages expose member data (e.g. emails); they are
+    restricted to superusers and the CSV is sent only to your browser.
+  </p>
+
+  <table id="result_list">
+    <thead>
+      <tr>
+        <th scope="col">{% translate 'Check' %}</th>
+        <th scope="col">{% translate 'Group' %}</th>
+        <th scope="col" class="dh-count-col">{% translate 'Flagged' %}</th>
+        <th scope="col">{% translate 'CSV' %}</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for check in checks %}
+        <tr class="{% cycle 'row1' 'row2' %}">
+          <th scope="row">
+            <a href="{% url 'admin:data_health_detail' check.slug %}">{{ check.title }}</a>
+            <div class="dh-desc">{{ check.description }}</div>
+          </th>
+          <td>{{ check.group }}</td>
+          <td class="dh-count-col">
+            <span class="dh-count {% if check.count %}dh-count-warn{% else %}dh-count-ok{% endif %}">
+              {{ check.count }}
+            </span>
+          </td>
+          <td><a href="{% url 'admin:data_health_export' check.slug %}">{% translate 'Download' %}</a></td>
+        </tr>
+      {% empty %}
+        <tr><td colspan="4">{% translate 'No checks registered.' %}</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+{% endblock %}
+
+{% block extrastyle %}
+{{ block.super }}
+<style>
+  .dh-intro { max-width: 60em; color: #555; margin: 0 0 16px; }
+  .dh-desc { font-size: 12px; color: #777; font-weight: normal; margin-top: 2px; }
+  .dh-count-col { text-align: right; white-space: nowrap; }
+  .dh-count { font-variant-numeric: tabular-nums; font-weight: 600; }
+  .dh-count-ok { color: #2e7d32; }
+  .dh-count-warn { color: #b54708; }
+  @media (prefers-color-scheme: dark) {
+    .dh-intro { color: #bbb; }
+    .dh-desc { color: #999; }
+    .dh-count-ok { color: #7bc47f; }
+    .dh-count-warn { color: #e8a14b; }
+  }
+</style>
+{% endblock %}

--- a/website/templates/admin/data_health/detail.html
+++ b/website/templates/admin/data_health/detail.html
@@ -1,0 +1,55 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block breadcrumbs %}
+  <div class="breadcrumbs">
+    <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
+    &rsaquo; <a href="{% url 'admin:data_health_dashboard' %}">{% translate 'Data Health' %}</a>
+    &rsaquo; {{ check.title }}
+  </div>
+{% endblock %}
+
+{% block content %}
+  <p class="dh-desc">{{ check.description }}</p>
+
+  <p class="dh-actions">
+    <a class="button" href="{% url 'admin:data_health_export' check.slug %}">{% translate 'Download CSV' %}</a>
+    <span class="dh-rowcount">{{ rows|length }} {% translate 'row(s)' %}</span>
+  </p>
+
+  {% if rows %}
+    <div class="dh-table-wrap">
+      <table id="result_list">
+        <thead>
+          <tr>
+            {% for col in columns %}<th scope="col">{{ col }}</th>{% endfor %}
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in rows %}
+            <tr class="{% cycle 'row1' 'row2' %}">
+              {% for cell in row %}<td>{{ cell }}</td>{% endfor %}
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  {% else %}
+    <p class="dh-empty">✅ {% translate 'Nothing flagged — this check is clean.' %}</p>
+  {% endif %}
+{% endblock %}
+
+{% block extrastyle %}
+{{ block.super }}
+<style>
+  .dh-desc { max-width: 60em; color: #666; margin: 0 0 12px; }
+  .dh-actions { margin: 0 0 16px; }
+  .dh-rowcount { margin-left: 12px; color: #777; }
+  .dh-table-wrap { overflow-x: auto; }
+  .dh-empty { font-size: 14px; color: #2e7d32; }
+  @media (prefers-color-scheme: dark) {
+    .dh-desc, .dh-rowcount { color: #aaa; }
+    .dh-empty { color: #7bc47f; }
+  }
+</style>
+{% endblock %}

--- a/website/templates/admin/index.html
+++ b/website/templates/admin/index.html
@@ -9,6 +9,14 @@
   {% endif %}
 </div>
 
+{% if user.is_superuser %}
+  <div class="ml-data-health">
+    <span class="ml-data-health-icon" aria-hidden="true">🩺</span>
+    <a href="{% url 'admin:data_health_dashboard' %}">Data Health dashboard</a>
+    <span class="ml-data-health-desc">— read-only data-quality checks (duplicate people, missing files, etc.) with CSV export.</span>
+  </div>
+{% endif %}
+
 <div id="content-main">
   {% if app_list %}
     {% for app in app_list %}
@@ -93,6 +101,35 @@
 
   .ml-version-description {
     color: #666;
+  }
+
+  /* Data Health entry point */
+  .ml-data-health {
+    background-color: #f1f8f4;
+    border: 1px solid #cfe8d8;
+    border-left: 4px solid #2e7d32;
+    padding: 10px 15px;
+    margin-bottom: 20px;
+    border-radius: 4px;
+    font-size: 14px;
+  }
+
+  .ml-data-health-icon {
+    margin-right: 6px;
+  }
+
+  .ml-data-health-desc {
+    color: #666;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .ml-data-health {
+      background-color: #25302a;
+      border-color: #3c5344;
+    }
+    .ml-data-health-desc {
+      color: #aaa;
+    }
   }
 
   /* Help text styling within category tables */

--- a/website/tests.py
+++ b/website/tests.py
@@ -1218,3 +1218,246 @@ class PublicationsViewQueryCountTests(DatabaseTestCase):
                 "with 20 publications — prefetch_related likely regressed"
             ),
         )
+
+
+# --- Data Health admin dashboard + checks (issue #1276) -------------------
+
+import os
+import shutil
+import tempfile
+
+from django.contrib.auth.models import User
+from django.test import override_settings
+
+from website.admin.data_health.registry import get_check
+from website.utils.name_utils import normalize_person_name, is_default_person_image
+
+
+class NameUtilsTests(SimpleTestCase):
+    """Unit tests for the shared name/image helpers (no DB)."""
+
+    def test_normalize_folds_accents_and_strips_nonalpha(self):
+        self.assertEqual(normalize_person_name("Jon", "Froehlich"), "jonfroehlich")
+        self.assertEqual(normalize_person_name("Renée", "O'Brien"), "reneeobrien")
+        self.assertEqual(normalize_person_name("Jon-Paul", "Smith Jr."), "jonpaulsmithjr")
+
+    def test_same_name_different_case_same_key(self):
+        self.assertEqual(
+            normalize_person_name("Jane", "Doe"),
+            normalize_person_name("jane", "doe"),
+        )
+
+    def test_default_image_detection(self):
+        self.assertTrue(is_default_person_image(None))
+
+        class _Empty:
+            name = ""
+
+        class _StarWars:
+            name = "person/jane_doe_easteregg_starwars_rebel.png"
+
+        class _Real:
+            name = "person/jane_doe.gif"
+
+        self.assertTrue(is_default_person_image(_Empty()))
+        self.assertTrue(is_default_person_image(_StarWars()))
+        self.assertFalse(is_default_person_image(_Real()))
+
+
+class DataHealthAuthTests(DatabaseTestCase):
+    """Superuser gating on the dashboard, detail, and export views."""
+
+    def setUp(self):
+        self.superuser = User.objects.create_superuser("root", "r@example.com", "pw")
+        self.staff = User.objects.create_user(
+            "staffer", "s@example.com", "pw", is_staff=True
+        )
+
+    def test_superuser_can_view_dashboard(self):
+        self.client.force_login(self.superuser)
+        resp = self.client.get(reverse("admin:data_health_dashboard"))
+        self.assertEqual(resp.status_code, 200)
+
+    def test_staff_nonsuperuser_forbidden(self):
+        self.client.force_login(self.staff)
+        for name, args in [
+            ("admin:data_health_dashboard", []),
+            ("admin:data_health_detail", ["duplicate-people"]),
+            ("admin:data_health_export", ["duplicate-people"]),
+        ]:
+            resp = self.client.get(reverse(name, args=args))
+            self.assertEqual(resp.status_code, 403, msg=name)
+
+    def test_anonymous_redirected_to_login(self):
+        resp = self.client.get(reverse("admin:data_health_dashboard"))
+        self.assertEqual(resp.status_code, 302)
+        self.assertIn("/admin/login/", resp["Location"])
+
+    def test_unknown_check_returns_404(self):
+        self.client.force_login(self.superuser)
+        resp = self.client.get(reverse("admin:data_health_detail", args=["nope"]))
+        self.assertEqual(resp.status_code, 404)
+
+
+class DataHealthCsvTests(DatabaseTestCase):
+    """The CSV export streams text/csv as an attachment with the right rows."""
+
+    def setUp(self):
+        self.superuser = User.objects.create_superuser("root", "r@example.com", "pw")
+        self.client.force_login(self.superuser)
+
+    def test_csv_headers_and_content(self):
+        self.make_person(first_name="Jane", last_name="Doe", email="jane@example.com")
+        self.make_person(first_name="Jane", last_name="Doe", email="jane2@example.com")
+        resp = self.client.get(
+            reverse("admin:data_health_export", args=["duplicate-people"])
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp["Content-Type"], "text/csv")
+        self.assertIn(
+            'attachment; filename="duplicate-people-', resp["Content-Disposition"]
+        )
+        body = resp.content.decode()
+        self.assertIn("cluster_key", body)  # header row
+        self.assertIn("jane@example.com", body)
+        self.assertIn("jane2@example.com", body)
+
+
+class DuplicatePeopleCheckTests(DatabaseTestCase):
+    def test_clusters_only_multi_person_same_name(self):
+        self.make_person(first_name="Jane", last_name="Doe")
+        self.make_person(first_name="Jane", last_name="Doe")
+        self.make_person(first_name="John", last_name="Smith")  # unique
+        rows = get_check("duplicate-people").get_rows()
+        self.assertEqual({r["cluster_key"] for r in rows}, {"janedoe"})
+        self.assertEqual(len(rows), 2)
+
+    def test_total_refs_counts_relations(self):
+        p1 = self.make_person(first_name="Jane", last_name="Doe")
+        p2 = self.make_person(first_name="Jane", last_name="Doe")
+        pub = self.make_publication(title="A Counted Paper")
+        pub.authors.add(p1)
+        rows = {r["id"]: r for r in get_check("duplicate-people").get_rows()}
+        self.assertEqual(rows[p1.pk]["pub_count"], 1)
+        self.assertEqual(rows[p1.pk]["total_refs"], 1)
+        self.assertEqual(rows[p2.pk]["total_refs"], 0)  # safe-to-delete shell
+
+    def test_clean_data_no_rows(self):
+        self.make_person(first_name="Solo", last_name="Person")
+        self.assertEqual(get_check("duplicate-people").get_rows(), [])
+
+
+class UrlNameCollisionsCheckTests(DatabaseTestCase):
+    def test_detects_forced_collision_and_placeholder(self):
+        from website.models import Person
+
+        self.make_person(first_name="Jane", last_name="Doe")
+        p2 = self.make_person(first_name="Jane", last_name="Doe")  # -> janedoe2
+        p3 = self.make_person(first_name="Solo", last_name="One")
+        # save() auto-dedupes url_name, so force a historical collision directly.
+        Person.objects.filter(pk=p2.pk).update(url_name="janedoe")
+        Person.objects.filter(pk=p3.pk).update(url_name="placeholder")
+
+        rows = {r["url_name"]: r for r in get_check("url-name-collisions").get_rows()}
+        self.assertIn("janedoe", rows)
+        self.assertEqual(rows["janedoe"]["count"], 2)
+        self.assertIn("placeholder", rows)
+
+
+class PublicationQualityCheckTests(DatabaseTestCase):
+    def test_duplicate_titles_and_missing_venue(self):
+        self.make_publication(title="Dup Paper")
+        self.make_publication(title="Dup Paper")  # duplicate normalized title
+        self.make_publication(title="No Venue Paper", forum_name=None)
+        rows = {r["id"]: r for r in get_check("publication-quality").get_rows()}
+        self.assertEqual(len([r for r in rows.values() if r["dup_title"]]), 2)
+        self.assertTrue(
+            any("forum_name" in r["missing_fields"] for r in rows.values())
+        )
+
+
+class ProjectHealthCheckTests(DatabaseTestCase):
+    def test_flags_incomplete_project(self):
+        from website.models import Project
+
+        Project.objects.create(name="Lonely Project", short_name="lonely")
+        rows = {r["name"]: r for r in get_check("project-health").get_rows()}
+        self.assertIn("Lonely Project", rows)
+        self.assertIn("no thumbnail", rows["Lonely Project"]["issues"])
+        self.assertIn("no publication", rows["Lonely Project"]["issues"])
+
+
+class PositionIntegrityCheckTests(DatabaseTestCase):
+    def test_no_position_and_self_advisor(self):
+        from datetime import date as _date
+
+        from website.models import Position
+        from website.models.position import Title
+
+        p_nopos = self.make_person(first_name="No", last_name="Position")
+        p_self = self.make_person(first_name="Self", last_name="Advisor")
+        Position.objects.create(
+            person=p_self,
+            start_date=_date(2020, 1, 1),
+            title=Title.PHD_STUDENT,
+            advisor=p_self,
+        )
+        issues = {
+            (r["person_id"], r["issue"])
+            for r in get_check("position-integrity").get_rows()
+        }
+        self.assertIn((p_nopos.pk, "no position"), issues)
+        self.assertIn((p_self.pk, "self-advisor"), issues)
+
+
+class NewsHealthCheckTests(DatabaseTestCase):
+    def test_flags_missing_slug_and_author(self):
+        from website.models import News
+
+        author = self.make_person(first_name="News", last_name="Writer")
+        n_noauthor = self.make_news_item(title="Orphan News", author=None)
+        n_noslug = self.make_news_item(title="Slugless News", author=author)
+        News.objects.filter(pk=n_noslug.pk).update(slug="")  # save() auto-slugs
+
+        rows = {r["id"]: r for r in get_check("news-health").get_rows()}
+        self.assertIn(n_noauthor.pk, rows)
+        self.assertFalse(rows[n_noauthor.pk]["has_author"])
+        self.assertIn(n_noslug.pk, rows)
+        self.assertTrue(rows[n_noslug.pk]["missing_slug"])
+
+
+class MediaIntegrityCheckTests(DatabaseTestCase):
+    def setUp(self):
+        # Use a throwaway MEDIA_ROOT so the test never pollutes dev media.
+        self._media_dir = tempfile.mkdtemp(prefix="dh_media_")
+        self._override = override_settings(MEDIA_ROOT=self._media_dir)
+        self._override.enable()
+        self.addCleanup(self._override.disable)
+        self.addCleanup(shutil.rmtree, self._media_dir, ignore_errors=True)
+
+    def test_flags_missing_file(self):
+        pub = self.make_publication(title="Vanishing Paper")
+        path = pub.pdf_file.path
+        if os.path.exists(path):
+            os.remove(path)  # simulate a file that disappeared from disk
+        hits = [
+            r
+            for r in get_check("media-integrity").get_rows()
+            if r["type"] == "Publication"
+            and r["id"] == pub.pk
+            and r["status"] == "missing-file"
+        ]
+        self.assertTrue(hits)
+
+
+class DataHealthReadOnlyTests(DatabaseTestCase):
+    def test_get_rows_does_not_mutate_db(self):
+        from website.models import Person, Publication
+
+        self.make_person(first_name="Jane", last_name="Doe")
+        self.make_person(first_name="Jane", last_name="Doe")
+        before = (Person.objects.count(), Publication.objects.count())
+        for slug in ("duplicate-people", "url-name-collisions", "position-integrity"):
+            get_check(slug).get_rows()
+        after = (Person.objects.count(), Publication.objects.count())
+        self.assertEqual(before, after)

--- a/website/utils/name_utils.py
+++ b/website/utils/name_utils.py
@@ -1,0 +1,71 @@
+"""
+Name-normalization helpers shared across the website app.
+
+The primary use is producing a stable, accent-folded key for a person's
+name so that records that *would* collide on ``Person.url_name`` can be
+detected and clustered. The logic mirrors the url_name derivation in
+``Person.save()`` (website/models/person.py) so callers — e.g. the
+duplicate-people data-health check and a future ``recompute_url_names``
+command — agree on what "the same name" means.
+"""
+
+import re
+
+# Common accented characters mapped to ASCII. Kept in sync with the map in
+# website/models/person.py used by Person.save() for url_name derivation.
+SPECIAL_CHARS = {
+    'ã': 'a', 'à': 'a', 'â': 'a',
+    'é': 'e', 'è': 'e', 'ê': 'e',
+    'ñ': 'n', 'ń': 'n',
+    'ö': 'o', 'ô': 'o',
+    'û': 'u', 'ü': 'u', 'ù': 'u',
+}
+
+# Substrings identifying the auto-assigned "Star Wars" placeholder images
+# (see get_path_to_random_starwars_image / get_upload_to_for_person_easter_egg).
+# NOTE: only the *easter_egg* (hover) field retains a "_starwars_" marker in its
+# stored filename; the headshot ``image`` default is saved under the person's
+# own name, so a default headshot is NOT reliably detectable by path. Treat
+# is_default_person_image() as a best-effort hint, not a guarantee.
+_STARWARS_MARKERS = ('StarWarsFiguresFullSquare', '_starwars_')
+
+
+def normalize_person_name(first_name, last_name):
+    """
+    Return the accent-folded, lowercased, alpha-only key for a name.
+
+    This reproduces the cleaning that ``Person.save()`` applies when deriving
+    ``url_name`` (minus the numeric-suffix collision loop), so two people share
+    a key exactly when their bare ``url_name`` would collide.
+
+    Example:
+        >>> normalize_person_name('Jon', 'Froehlich')
+        'jonfroehlich'
+        >>> normalize_person_name('Renée', "O'Brien")
+        'reneeobrien'
+    """
+    cleaned = f"{first_name or ''}{last_name or ''}".lower()
+    for c in cleaned:
+        if re.search('[^a-zA-Z]', c) and c in SPECIAL_CHARS:
+            cleaned = cleaned.replace(c, SPECIAL_CHARS[c])
+    return re.sub('[^a-zA-Z]', '', cleaned)
+
+
+def is_default_person_image(image_field):
+    """
+    Return True if a Person image field looks like an auto-assigned default
+    (random "Star Wars" placeholder) rather than a real upload.
+
+    ``Person.save()`` assigns a random Star Wars image when none is set, so
+    "has an image" is meaningless on its own. Accepts a Django file field
+    (``person.image`` / ``person.easter_egg``) or any object with a ``.name``;
+    falsy/empty fields count as default.
+
+    Caveat: reliable only for the *easter_egg* field (whose default keeps a
+    ``_starwars_`` marker). A default *headshot* is stored under the person's
+    name and cannot be told apart from a real upload by path alone.
+    """
+    name = getattr(image_field, 'name', None) or ''
+    if not name:
+        return True
+    return any(marker in name for marker in _STARWARS_MARKERS)


### PR DESCRIPTION
## Summary

Adds a small, **read-only, superuser-gated "Data Health" admin area** at `/admin/data-health/` that surfaces data-quality problems and lets a maintainer download each report as a CSV. A dashboard hub lists every check with a live count; each check has a detail page (full table + **Download CSV**).

Closes #1276. The `duplicate-people` check also serves #1275's Phase B analysis, and `url-name-collisions` surfaces the #1206 source.

## Motivation

The prod/test servers are **push-deploy only with no shell or DB access** (the DB is the in-stack `db` container bound to the host loopback). That leaves **no ad-hoc query capability against live data**. These pages run *inside* the container (so they have DB access), behind the existing `/admin` superuser login, and generate CSVs **in the request** — streamed only to the authenticated browser, never written to a web-served path (avoiding the stale public `dumped_data.json` mistake). This PR also documents that access model in `CLAUDE.md`.

## What's included

**Framework** (`website/admin/data_health/`)
- `registry.py` — `HealthCheck` base, `@register_check`, ordered `REGISTRY`, and the on-the-fly `rows_to_csv_response`.
- `views.py` — `dashboard` / `detail` / `export_csv`, each superuser-gated.
- Wired via `MakeabilityLabAdminSite.get_urls()` + a superuser-only card on the admin index.
- `website/utils/name_utils.py` — `normalize_person_name()` (mirrors `Person.save()`'s `url_name` logic; reusable by a future `recompute_url_names` command) and `is_default_person_image()`.

**7 checks** (each `checks/<name>.py`, all strictly read-only)
| Check | Surfaces |
|---|---|
| `duplicate-people` | Person clusters sharing a normalized name + full per-person ref counts (serves #1275) |
| `url-name-collisions` | Person rows sharing a `url_name` / `placeholder` (the live #1206 500 source) |
| `media-integrity` | Artifact file fields pointing at missing files + orphaned files on disk |
| `publication-quality` | Publications missing PDF/date/venue/thumbnail; duplicate titles |
| `project-health` | Projects with no thumbnail/publication/active members/umbrella |
| `position-integrity` | Missing positions, inverted date ranges, self-referential advisor links |
| `news-health` | News missing a slug or author |

## Testing

- **18 new tests** + full suite **92 passing**: superuser gating (200 / 403 / 302), per-check row/count assertions, CSV content-type + attachment headers, a read-only guarantee, and `name_utils` unit tests. `media-integrity` uses a temp `MEDIA_ROOT` so it never touches dev media.
- Smoke-ran every check against the real dev DB; verified locally in the browser.

## Notes / caveats
- `has_real_image` (in the dedup export) is **best-effort**: a default *headshot* is stored under the person's name with no Star Wars marker, so only the easter-egg-style default is reliably detectable (documented in `name_utils.py`).
- `video_count` is always 0 — `Video` has no `authors` relation today; kept for parity with the #1275 export spec.

## Commits
1. Document server access model + correct DB/config facts in `CLAUDE.md`
2. Add the Data Health dashboard + 7 checks
3. Add tests

## Screenshots
<img width="1512" height="727" alt="image" src="https://github.com/user-attachments/assets/a38779ba-de12-49bb-bfbd-8413f126fef6" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)