### PR TITLE
Fix mobile navbar sizing/wrap and logo overflow (#1281, #1282, #1286)

### DIFF
--- a/website/static/website/css/top-navbar.css
+++ b/website/static/website/css/top-navbar.css
@@ -219,11 +219,14 @@
 }
 
 /* ==========================================================================
-   Responsive Styles - Mobile (Collapsed Menu)
-   
-   Bootstrap 3 navbar collapses at 768px by default, but experimentally
-   this occurs at 789px for this navbar configuration.
-   
+   Responsive Styles - Mobile / Tablet (Collapsed Menu)
+
+   The collapsed (hamburger) menu is used up to 991px. The brand + 8 menu items
+   don't fit on one horizontal line until ~970px, so collapsing at Bootstrap's
+   default 768px left the menu wrapping onto a second line between ~768–991px
+   (issue #1286). The breakpoint override further below re-asserts the collapsed
+   layout across 768–991px; these rules style that collapsed menu.
+
    Key mobile improvements:
    - Minimum 44px touch targets (Apple HIG guideline)
    - Larger font size for readability
@@ -231,10 +234,65 @@
    - Clear visual separation between items
    ========================================================================== */
 
-@media only screen and (max-width: 789px) {
+@media only screen and (max-width: 991px) {
+  /*
+   * Taller navbar on mobile. The default 40px height left the hamburger button
+   * small and hard to tap, and felt disproportionately short next to the
+   * enlarged collapsed menu items. See issue #1282.
+   */
+  .navbar-custom {
+    height: 56px;
+    padding-top: 0;
+  }
+
+  /* Vertically center the brand (logo + text) within the taller navbar. The
+     float (set by Bootstrap) still positions it on the left. */
+  .navbar-custom .navbar-brand {
+    display: flex;
+    align-items: center;
+    height: 56px;
+  }
+
+  /* Scale the logo mark up to suit the taller navbar (the 20px default looked
+     undersized and top-light in a 56px bar). Width stays auto to keep ratio. */
+  .navbar-custom .navbar-brand > img {
+    height: 32px;
+  }
+
+  /* Logo-only brand on mobile. The wordmark looked tiny and cramped next to the
+     enlarged logo, so we hide it here. The brand link keeps an accessible name
+     via the aria-label on the <a> in base.html. See issue #1282 discussion. */
+  .navbar-custom .makeabilitylab-text {
+    display: none;
+  }
+
+  /* Larger hamburger button: ≥44px touch target (Apple HIG) with a bigger icon,
+     vertically centered within the navbar. Float keeps it on the right. */
+  .navbar-custom .navbar-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 56px;
+    min-width: 48px;
+    padding: 0 14px;
+    margin: 0;
+  }
+
+  .navbar-custom .navbar-toggle .fa-bars {
+    font-size: 26px;
+  }
+
   /* Collapsed menu background */
   .navbar-collapse ul {
     background-color: var(--navbar-bg-color);
+  }
+
+  /* Make the dropdown sit flush against the navbar. Bootstrap's default 7.5px
+     top margin on .navbar-nav left a gap where the page showed through between
+     the navbar and the menu panel. See issue #1282 discussion. */
+  .navbar-custom .navbar-nav {
+    margin-top: 0;
+    margin-bottom: 0;
   }
 
   /* 
@@ -255,6 +313,13 @@
   .navbar-custom .nav-icon {
     display: inline-block;
     font-size: 18px;
+  }
+
+  /* Stack menu items vertically. Bootstrap floats them left ≥768px; the
+     breakpoint override below keeps the menu collapsed up to 991px, so the
+     items must not float there. (No-op below 768px.) */
+  .navbar-custom .navbar-nav > li {
+    float: none;
   }
 
   /* Add subtle separator between menu items */
@@ -287,10 +352,38 @@
 }
 
 /* ==========================================================================
+   Raise the navbar collapse breakpoint to 992px
+
+   Bootstrap 3.3.6 switches the navbar to its horizontal layout at 768px, but
+   the brand + 8 menu items don't fit on one line until ~970px — so between
+   768–991px the menu wrapped onto a second line (issue #1286). These rules
+   re-assert Bootstrap's collapsed (hamburger) layout across 768–991px, so the
+   horizontal menu only appears once it actually fits (≥992px). The collapsed
+   styling itself comes from the max-width: 991px block above.
+   ========================================================================== */
+
+@media (min-width: 768px) and (max-width: 991px) {
+  /* Don't float the header into a horizontal row */
+  .navbar-custom .navbar-header {
+    float: none;
+  }
+
+  /* Keep the dropdown hidden until toggled (Bootstrap forces it open ≥768px) */
+  .navbar-custom .navbar-collapse.collapse {
+    display: none !important;
+  }
+
+  .navbar-custom .navbar-collapse.collapse.in {
+    display: block !important;
+    overflow-y: auto !important;
+  }
+}
+
+/* ==========================================================================
    Light Theme Mobile Adjustments
    ========================================================================== */
 
-@media only screen and (max-width: 789px) {
+@media only screen and (max-width: 991px) {
   .light-navbar-theme .navbar-nav > li {
     border-bottom-color: rgba(0, 0, 0, 0.1);
   }

--- a/website/static/website/js/makelab-logo.js
+++ b/website/static/website/js/makelab-logo.js
@@ -35,6 +35,7 @@
  */
 
 import {
+  MakeabilityLabLogo,
   MakeabilityLabLogoMorpher,
   TriangleArt,
 } from 'https://cdn.jsdelivr.net/gh/makeabilitylab/js@main/dist/makelab.logo.js';
@@ -45,6 +46,9 @@ import {
 
 const MAX_HEIGHT = 600;
 const TRIANGLE_SIZE = 70;
+// Keep the assembled logo within this fraction of the canvas width so it never
+// runs off-screen on narrow (mobile) viewports. See issue #1281.
+const LOGO_WIDTH_FRACTION = 0.9;
 const SCROLL_DISTANCE = 300;
 const DPR = window.devicePixelRatio || 1;
 const BG_FILL_COLOR = "rgba(255, 255, 255, 1)"; // Solid white for website clean look
@@ -112,6 +116,15 @@ async function initOrResize() {
   if (!morpher) {
     morpher = new MakeabilityLabLogoMorpher(0, 0, TRIANGLE_SIZE, START_FILL_COLOR);
   }
+
+  // Size the assembled logo so it always fits within the canvas width. On wide
+  // (desktop) canvases this caps at the natural size (TRIANGLE_SIZE per cell);
+  // on narrow (mobile) canvases it shrinks the logo so the final, unexploded
+  // state stays fully on-screen. Must run before reset()/resetFromArt() below,
+  // which read the logo's cell size to compute the morph end state. See #1281.
+  const naturalLogoWidth = MakeabilityLabLogo.numCols * TRIANGLE_SIZE;
+  const maxLogoWidth = logicalWidth * LOGO_WIDTH_FRACTION;
+  morpher.setLogoSize(Math.min(naturalLogoWidth, maxLogoWidth));
 
   // Ensure the destination logo is centered in the final state
   morpher.centerLogo(logicalWidth, logicalHeight);

--- a/website/templates/website/base.html
+++ b/website/templates/website/base.html
@@ -162,8 +162,9 @@ TEMPLATE BLOCKS:
                 <span class="sr-only">Menu</span>
               </button>
 
-              <a class="navbar-brand page-scroll" href="{% url 'website:index' %}">
-                <img src="{% static 'website/img/logos/makelab_logo_white_no_text_100x67.png' %}" 
+              <a class="navbar-brand page-scroll" href="{% url 'website:index' %}"
+                 aria-label="Makeability Lab home">
+                <img src="{% static 'website/img/logos/makelab_logo_white_no_text_100x67.png' %}"
                      alt=""
                      height="20"
                      aria-hidden="true">


### PR DESCRIPTION
## Summary
Three related mobile UI fixes, verified with headless Chrome at real mobile/tablet widths.

### #1281 — Logo animation runs off-screen on mobile
The interactive logo's final (assembled) state was built at a fixed triangle size (~420px wide) regardless of canvas width, so it overflowed the right edge on phones. Now the assembled logo is capped to `min(naturalWidth, canvasWidth * 0.9)` (via `setLogoSize()`, before the morph end-state is computed). Desktop is unchanged (it always exceeds the cap); mobile shrinks to fit.

### #1282 — Mobile navbar too short / hamburger hard to tap
- Navbar height `40px → 56px` (Material standard; the old 40px was below Bootstrap's own 50px default).
- Hamburger → flex-centered, `min-width: 48px`, `height: 56px`, `26px` icon (clears Apple HIG 44pt / Material 48dp).
- Logo scaled `20px → 32px` and vertically centered.
- Wordmark hidden on mobile (logo-only) — it looked tiny/cramped next to the larger logo. The brand link keeps an accessible name via `aria-label="Makeability Lab home"`, so screen-reader output is preserved.
- Dropdown now sits **flush** against the navbar (Bootstrap's default `7.5px` `.navbar-nav` top margin had left a visible gap).

### #1286 — Navbar wraps to a second line at some widths
Bootstrap 3.3.6 floats the navbar horizontal at **768px**, but the brand + 8 items don't fit until **~970px**, so the menu wrapped between ~768–991px. Fixed by raising the collapse breakpoint to **992px**: collapsed-menu styles extended to `max-width: 991px` plus a `768–991px` override that re-asserts Bootstrap's collapsed layout. The horizontal menu now appears only once it actually fits.

## Files
- `website/static/website/js/makelab-logo.js` — logo width cap (#1281)
- `website/static/website/css/top-navbar.css` — navbar height, hamburger, logo, flush dropdown, breakpoint raise (#1282, #1286)
- `website/templates/website/base.html` — brand `aria-label` (#1282)

## Behavior change to note
Tablets / narrow laptop windows from **768–991px** now get the hamburger menu instead of the horizontal one (the horizontal menu can't fit there anyway).

## Testing
Verified across widths 390 → 1200px via headless Chrome (DevTools protocol, real reflows):
- ≤ 980px: hamburger, no wrap; dropdown stacks vertically and flush
- 992px+: full horizontal menu on one line, desktop wordmark returns
- Logo-only brand and flush dropdown confirmed at 390px

Before screenshots: see #1281, #1282, #1286.

Closes #1281
Closes #1282
Closes #1286

🤖 Generated with [Claude Code](https://claude.com/claude-code)