### PR TITLE
Remove dead Bootstrap scrollspy from <body> (#1288)

### DIFF
--- a/website/templates/website/base.html
+++ b/website/templates/website/base.html
@@ -133,7 +133,7 @@ TEMPLATE BLOCKS:
   {% endif %}
 </head>
 
-<body id="page-top" data-spy="scroll" data-target=".navbar-fixed-top">
+<body id="page-top">
 
   <!-- Skip link for keyboard users (WCAG 2.4.1: Bypass Blocks) -->
   <a href="#content" class="skip-link">Skip to main content</a>


### PR DESCRIPTION
Third step of **Track A** (#1288), the JS half of the Bootstrap+jQuery removal (#1253). Follows #1289 and #1290.

## What
Removes `data-spy="scroll" data-target=".navbar-fixed-top"` from the `<body>` tag. One-line change.

## Why it's a no-op (safe)
Bootstrap scrollspy only activates nav links whose `href` is an in-page `#anchor` matching an on-page element. The main navbar (`.navbar-fixed-top`) contains only full page-URL links (`/publications`, `/people`, …) and external links — **zero `#anchors`** — so scrollspy matched nothing and just attached a wasted scroll listener.

- In-page section nav on **publications/awards** is **tocbot**, independent of Bootstrap.
- The navbar's **active-page highlight** is server-side template logic (`{% if url_name == ... %}active`), **not** scrollspy.

So nothing to convert to IntersectionObserver — this just deletes a dead attribute and drops one more Bootstrap-JS dependency point.

## Verification
All pages return **HTTP 200**; `data-spy` gone from served HTML; active-page highlight unchanged across `/`, `/publications`, `/people`, `/awards`.

Refs #1253.