### PR TITLE
Drop jQuery 1.9.1 + Bootstrap 3.3.6 JavaScript (#1288)

### DIFF
--- a/website/static/website/js/project-sidebar-sticky.js
+++ b/website/static/website/js/project-sidebar-sticky.js
@@ -36,7 +36,7 @@
  *
  * Only active on >=992px breakpoint; the mobile layout doesn't use sticky.
  *
- * Vanilla JS — no jQuery dependency despite the rest of the codebase using it.
+ * Vanilla JS — no jQuery dependency.
  */
 (function () {
   'use strict';

--- a/website/templates/website/base.html
+++ b/website/templates/website/base.html
@@ -97,11 +97,8 @@ TEMPLATE BLOCKS:
 
   {% block stylesheets %}{% endblock %}
 
-  <!-- JavaScript libraries (jQuery 1.9.1 required by Bootstrap 3.3.6) -->
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js" 
-          integrity="sha384-0mSbJDEHialfmuBBQP6A4Qrprq5OVfW37PRR3j5ELqxss1yVqOtnepnHVP9aJ7xS" 
-          crossorigin="anonymous"></script>
+  <!-- Site JavaScript (vanilla; no jQuery / Bootstrap JS — see #1288).
+       Bootstrap's CSS is still used; only its JavaScript was removed. -->
   <script src="{% static 'website/js/top-navbar.js' %}"></script>
   <script src="{% static 'website/js/carousel.js' %}"></script>
 


### PR DESCRIPTION
**Capstone of Track A** (#1288 / #1253). Removes the jQuery 1.9.1 and Bootstrap 3.3.6 `<script>` tags from `base.html` — they're now unused.

## Why this is safe now
With the navbar (#1290), scrollspy (#1291), citation popover (#1292), and carousel (#1293) all converted to vanilla JS, nothing in the frontend uses jQuery or Bootstrap JS anymore. Verified on `master` after those merges:
- **0** `$(...)` / `jQuery` calls in our JS.
- **0** inline `$()` blocks in any template.
- **0** Bootstrap-JS data-api attributes (`data-ride`/`data-spy`/`data-slide-to`/`data-toggle="collapse"`/modal/tab/tooltip/dropdown) — the only remaining `data-toggle="popover"` is an inert selector for the vanilla popover (Bootstrap popovers have no data-api).
- `base.html` was the only template that loaded these libraries.

## What changes
- Remove the jQuery 1.9.1 and Bootstrap 3.3.6 JS `<script>` tags from `base.html`.
- Tidy a now-stale comment in `project-sidebar-sticky.js`.

**Bootstrap CSS stays** (`bootstrap.min.css`) — only the JavaScript is removed. The grid/CSS migration is the separate Track B.

## Payoff
- Drops ~70KB of CDN JS (jQuery ~33KB + Bootstrap JS ~37KB, minified) from **every** page.
- Removes **jQuery 1.9.1** (2013), which has known XSS vulnerabilities.
- The frontend is now jQuery-free and Bootstrap-JS-free.

## Verification
All pages return **HTTP 200** with no `jquery`/`bootstrap*.js` in served HTML and `bootstrap.min.css` still present (`/`, `/publications`, `/awards`, `/people`, `/projects`, `/news`, a project page). Each interactive component was verified in-browser in its own PR; this PR is the first time they run with the libraries fully absent, so a final in-browser smoke-check of navbar + citation popover + carousel is worthwhile before merge.

Closes #1288. Refs #1253.