### PR TITLE
Remove redundant allowfullscreen on video iframes (#1296)

### DIFF
--- a/website/templates/snippets/display_video_snippet.html
+++ b/website/templates/snippets/display_video_snippet.html
@@ -47,8 +47,7 @@ NOTE ON VIDEO AGE:
             src="{{ video.get_embed }}" 
             title="Video: {{ video.title }}"
             frameborder="0" 
-            allow="autoplay; fullscreen" 
-            allowfullscreen
+            allow="autoplay; fullscreen"
             loading="lazy">
     </iframe>
   </div>

--- a/website/templates/website/project.html
+++ b/website/templates/website/project.html
@@ -159,8 +159,7 @@ document.addEventListener('DOMContentLoaded', function() {
           <iframe class="project-featured-video-player" 
                   src="{{ featured_video.get_embed }}" 
                   title="Featured video: {{ featured_video.title }}"
-                  allow="autoplay; fullscreen" 
-                  allowfullscreen
+                  allow="autoplay; fullscreen"
                   loading="lazy">
           </iframe>
         </div>


### PR DESCRIPTION
Small cleanup spotted during Track A (#1288).

## What
The video-embed iframes set **both** `allow="autoplay; fullscreen"` and the legacy `allowfullscreen` attribute, which makes Chrome log: *"Allow attribute will take precedence over 'allowfullscreen'."* The `allow` Permissions-Policy token already grants fullscreen, so `allowfullscreen` is redundant. Removed it from both:
- `website/templates/snippets/display_video_snippet.html`
- `website/templates/website/project.html`

## Verification
Homepage renders 3 video iframes, all with `allow="autoplay; fullscreen"` and **0** legacy `allowfullscreen`; pages still 200. No behavior change (fullscreen still allowed via `allow`); silences the console warning.

## Note on the other console item
The non-passive scroll-listener violation (×36) from that session is **not** ours: `makelab-logo.js`'s scroll listener is already `{ passive: true }` and no Track A code adds scroll/touch/wheel listeners — it's almost certainly a browser extension.

Closes #1296.