### PR TITLE
Pin sitemap URLs to https; bump to 2.8.2 (#1252)

### DIFF
--- a/makeabilitylab/settings.py
+++ b/makeabilitylab/settings.py
@@ -72,8 +72,8 @@ else:
     ALLOWED_HOSTS = ['*']
 
 # Makeability Lab Global Variables, including Makeability Lab version
-ML_WEBSITE_VERSION = "2.8.1" # Keep this updated with each release and also change the short description below
-ML_WEBSITE_VERSION_DESCRIPTION = "SEO: add a dynamic sitemap.xml and advertise it in robots.txt (#1252). /sitemap.xml is generated on each request from our querysets via django.contrib.sitemaps — static listing pages (home, people, publications, projects, awards, news), visible projects, people with a position, and news items — so it stays current with no maintenance. It emits the correct per-environment domain via RequestSite, so no django.contrib.sites and no DB migration are needed. The top-level static robots.txt (served directly by Apache, not Django) now points crawlers at the sitemap. Remaining one-time step: submit the sitemap in Google Search Console once it is live on production."
+ML_WEBSITE_VERSION = "2.8.2" # Keep this updated with each release and also change the short description below
+ML_WEBSITE_VERSION_DESCRIPTION = "SEO: add a dynamic sitemap.xml and advertise it in robots.txt (#1252). /sitemap.xml is generated on each request from our querysets via django.contrib.sitemaps — static listing pages (home, people, publications, projects, awards, news), visible projects, people with a position, and news items — so it stays current with no maintenance. It emits the correct per-environment domain via RequestSite (no django.contrib.sites, no DB migration) and pins URLs to https so the sitemap lists canonical links rather than http URLs that 302-redirect. Validated on the test server: all 189 sitemap URLs return 200. The top-level static robots.txt (served directly by Apache, not Django) now points crawlers at the sitemap. Remaining one-time step: submit the sitemap in Google Search Console once it is live on production."
 DATE_MAKEABILITYLAB_FORMED = datetime.date(2012, 1, 1)  # Date Makeability Lab was formed
 MAX_BANNERS = 7 # Maximum number of banners on a page
 

--- a/website/sitemaps.py
+++ b/website/sitemaps.py
@@ -27,7 +27,22 @@ from django.urls import reverse
 from website.models import Project, Person, News
 
 
-class StaticViewSitemap(Sitemap):
+class _HttpsSitemap(Sitemap):
+    """
+    Base sitemap that pins generated URLs to the https scheme.
+
+    Apache terminates TLS and proxies to Django over plain HTTP, so the
+    request scheme Django sees is ``http``. Without this, RequestSite would
+    emit ``http://`` <loc> URLs that only 302-redirect to https — making the
+    sitemap advertise non-canonical URLs with an extra hop. Pinning the
+    protocol here makes every sitemap list the canonical https URLs directly.
+    (Cosmetic only in local dev, where the site is served over http.)
+    """
+
+    protocol = "https"
+
+
+class StaticViewSitemap(_HttpsSitemap):
     """Top-level listing pages that aren't tied to a single model instance."""
 
     changefreq = "weekly"
@@ -48,7 +63,7 @@ class StaticViewSitemap(Sitemap):
         return reverse(item)
 
 
-class ProjectSitemap(Sitemap):
+class ProjectSitemap(_HttpsSitemap):
     """Public project pages: /project/<short_name>/."""
 
     changefreq = "weekly"
@@ -69,7 +84,7 @@ class ProjectSitemap(Sitemap):
         return obj.updated
 
 
-class PersonSitemap(Sitemap):
+class PersonSitemap(_HttpsSitemap):
     """Public people pages: /member/<url_name>/."""
 
     changefreq = "monthly"
@@ -95,7 +110,7 @@ class PersonSitemap(Sitemap):
         return obj.bio_datetime_modified
 
 
-class NewsSitemap(Sitemap):
+class NewsSitemap(_HttpsSitemap):
     """News item pages: /news/<slug>/."""
 
     changefreq = "monthly"

--- a/website/tests/test_sitemap.py
+++ b/website/tests/test_sitemap.py
@@ -8,6 +8,7 @@ Note: robots.txt is a static file (./robots.txt) served by Apache on the
 servers, not a Django view, so it isn't covered here.
 """
 
+import re
 from datetime import date
 
 from website.tests.base import DatabaseTestCase
@@ -58,3 +59,17 @@ class SitemapTests(DatabaseTestCase):
         news = self.make_news_item(title="Big Lab News")
         body = self.client.get("/sitemap.xml").content.decode()
         self.assertIn(f"/news/{news.slug}/", body)
+
+    def test_sitemap_uses_https_scheme(self):
+        # Apache proxies to Django over plain HTTP, so without a pinned
+        # protocol the <loc> URLs would be http:// and only 302-redirect to
+        # https. Every <loc> must be canonical https. See _HttpsSitemap.
+        self.make_project(name="Scheme Proj", short_name="schemeproj",
+                          is_visible=True)
+        body = self.client.get("/sitemap.xml").content.decode()
+        locs = re.findall(r"<loc>(.*?)</loc>", body)
+        self.assertTrue(locs)  # guard against an empty sitemap passing vacuously
+        self.assertFalse(
+            [loc for loc in locs if not loc.startswith("https://")],
+            "all sitemap <loc> URLs should use the https scheme",
+        )


### PR DESCRIPTION
Refs #1252. Final follow-up before the prod release.

## What the test-server validation found

After #1309 deployed to `-test`, I crawled the live sitemap:

- ✅ XML well-formed, 189 URLs, all on the correct host.
- ✅ `robots.txt` now served with today's `Last-Modified` and the `Sitemap:` line (confirms the repo's static `./robots.txt` is the served file).
- ⚠️ **Every `<loc>` was an `http://` URL that 302-redirects to `https://`.** Following the redirects, all **189/189 return 200** — no dead links — but advertising non-canonical `http` URLs with an extra hop is bad for SEO.

**Cause:** Apache terminates TLS and proxies to Django over plain HTTP, so `RequestSite` sees the `http` request scheme.

## Fix

- Add an `_HttpsSitemap` base class (`protocol = "https"`) and have all four sitemaps extend it, so `<loc>` URLs are canonical `https://`.
- Add a regression test asserting every `<loc>` uses `https`.
- Bump `2.8.1 → 2.8.2`; release description notes the fix and the 189/189 → 200 validation.

## Testing

- `Ran 7 tests` in `test_sitemap.py`, all pass; full suite green.
- Verified locally the sitemap now emits `https://…` `<loc>` URLs.

## Validation summary (on `-test`, before this fix)

| Check | Result |
|---|---|
| sitemap.xml well-formed | ✅ |
| URL count | 189 (< 50k limit) |
| All on correct host | ✅ |
| All URLs reachable (final) | ✅ 189/189 → 200 |
| robots.txt advertises sitemap | ✅ |
| `<loc>` scheme | ⚠️ http → **fixed to https here** |

After this merges to `-test` I'll re-curl to confirm `https` `<loc>`s, then this same `2.8.2` is ready to tag for production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)