### PR TITLE
fix(video): render "Today" instead of "0 seconds ago" (#1091)

### DIFF
--- a/website/static/website/js/video-age.js
+++ b/website/static/website/js/video-age.js
@@ -54,6 +54,14 @@ const VideoAge = (function() {
     round: true  // Round to nearest unit
   };
 
+  /**
+   * Milliseconds in a day. Video dates have day granularity (server computes
+   * age from a DateField), so any age below this means "published today".
+   * Without this guard, a same-day video humanizes to "0 seconds ago" — the
+   * symptom reported in issue #1091.
+   */
+  const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
 
   // ==========================================================================
   // INITIALIZATION
@@ -134,9 +142,13 @@ const VideoAge = (function() {
    * 
    * @private
    * @param {number} ageInMs - Age in milliseconds
-   * @returns {string} Formatted string like "2 years ago"
+   * @returns {string} Formatted string like "2 years ago", or "Today" for a
+   *   video published today (avoids "0 seconds ago" — issue #1091)
    */
   function formatPastAge(ageInMs) {
+    if (ageInMs < ONE_DAY_MS) {
+      return 'Today';
+    }
     try {
       const humanized = humanizeDuration(ageInMs, HUMANIZE_OPTIONS);
       return humanized + ' ago';

--- a/website/tests/test_video.py
+++ b/website/tests/test_video.py
@@ -26,6 +26,18 @@ class VideoAgeTests(SimpleTestCase):
         # 7 days in ms, allowing slack for the now() call crossing midnight.
         self.assertGreaterEqual(age, 6 * 24 * 60 * 60 * 1000)
 
+    def test_today_is_below_one_day(self):
+        # A video published today must yield an age below one day in ms. This
+        # is the contract video-age.js relies on to render "Today" instead of
+        # "0 seconds ago" (issue #1091); pin it server-side since the JS guard
+        # itself has no test runner in this repo.
+        from website.models import Video
+        one_day_ms = 24 * 60 * 60 * 1000
+        age = Video(date=date.today()).get_age_in_ms()
+        self.assertIsInstance(age, int)
+        self.assertGreaterEqual(age, 0)
+        self.assertLess(age, one_day_ms)
+
     def test_future_date_returns_negative_int(self):
         from website.models import Video
         age = Video(date=date.today() + timedelta(days=7)).get_age_in_ms()


### PR DESCRIPTION
## Summary
Addresses #1091 (already closed — this is the remaining code-level hardening).

Video dates have day granularity (server computes age from a `DateField`), so a video published *today* humanized to "0 seconds ago" — the symptom from #1091. `video-age.js` now renders **"Today"** for any age below one day.

The screenshot's original case (a genuinely 2-week-old video showing "0 secs ago") was already resolved by the earlier rendering rework — moving off inline `document.write()` into `video-age.js`, the null-`date` guard, and future-date handling (#1208). That was a stale/creation-date data issue, not a math bug. This PR just closes the last same-day edge so the literal symptom can't reappear.

## Changes
- `website/static/website/js/video-age.js` — `formatPastAge()` returns "Today" when age `< ONE_DAY_MS`.
- `website/tests/test_video.py` — new `test_today_is_below_one_day` pins the server-side contract the JS guard relies on (a video dated today yields an age below one day in ms). The JS guard itself has no unit test because the repo intentionally has no frontend build/test step.

## Testing
`python manage.py test website.tests.test_video --settings=makeabilitylab.settings_test` → 4 tests pass.

No screenshot: this is a string-only change with no layout impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)