### PR TITLE
fix(carousel): eliminate banner "blink" on crossfade switch (#1010)

### DIFF
--- a/website/static/website/css/carousel_fade.css
+++ b/website/static/website/css/carousel_fade.css
@@ -10,6 +10,14 @@
  * (.next/.prev/.left/.right); that machinery went away with the Bootstrap
  * carousel JS (Track A — issues #1288 / #1253), so the fade is now self-
  * contained CSS rather than a hack layered on Bootstrap's animation.
+ *
+ * Dip-free crossfade (issue #1010): the transition is asymmetric on purpose.
+ * The INCOMING slide fades in (opacity 0 -> 1) while the OUTGOING slide holds
+ * at full opacity, then snaps to 0 only after the incoming has fully covered
+ * it. This guarantees an opaque slide always covers the carousel's magenta
+ * gradient backdrop (#main-carousel in base.css). A naive *symmetric* crossfade
+ * (both slides fading at once) lets up to ~25% of that backdrop bleed through
+ * at the midpoint, which read as a "blink"/flash when switching banners.
  */
 
 .carousel-fade .carousel-inner > .item {
@@ -23,19 +31,24 @@
   z-index: 0;
   /* Only the visible slide should capture clicks. */
   pointer-events: none;
-  transition: opacity 0.6s ease-in-out;
+  /* Deactivating: hold opacity (0s change) until the incoming slide has faded
+     fully in, i.e. delay the snap-to-0 by the fade duration. */
+  transition: opacity 0s ease-in-out 0.6s;
 }
 
 .carousel-fade .carousel-inner > .item.active {
   opacity: 1;
   z-index: 1;
   pointer-events: auto;
+  /* Activating: fade in over the still-opaque outgoing slide. */
+  transition: opacity 0.6s ease-in-out 0s;
 }
 
 /* Respect users who prefer reduced motion: switch instantly, no crossfade.
    (carousel.js also disables autoplay under this preference.) */
 @media (prefers-reduced-motion: reduce) {
-  .carousel-fade .carousel-inner > .item {
+  .carousel-fade .carousel-inner > .item,
+  .carousel-fade .carousel-inner > .item.active {
     transition: none;
   }
 }


### PR DESCRIPTION
## What & why

Fixes #1010 — the hero/banner carousel **"blinks"** (a pink/magenta flash) when switching between banners on multi-banner pages.

**Root cause.** The crossfade was *symmetric*: on switch, the outgoing slide faded `1→0` while the incoming faded `0→1` simultaneously. Each slide is an opaque unit (black bg + cover image), so while both are semi-transparent mid-transition, up to **~25% of `#main-carousel`'s bright magenta gradient backdrop bleeds through at the midpoint** — the visible blink.

**Fix.** Make the crossfade *dip-free* by splitting the transition (CSS only, `carousel_fade.css`): the incoming slide fades **in over a still-opaque outgoing slide**, which only snaps to 0 (`0s` change, delayed by the fade duration) once it's fully covered. An opaque slide always covers the backdrop → zero bleed-through, while the 0.6s crossfade look is preserved. Reduced-motion still gets an instant cut.

## Context on #1010

The original 2022 report predates the Bootstrap→vanilla carousel rewrite (#1288). That rewrite already fixed the *decode-lag* trigger (huge undecoded images) via server-side thumbnailing; this PR addresses the **crossfade backdrop-bleed** that the rewrite carried over. So #1010 is now fully resolved.

## Verification

Drove the real page (`/project/handsight`, 3 banners) in a headless browser, slowed the crossfade to 2s, and screenshotted the **exact transition midpoint** under both the old and new CSS:

| | Midpoint mean RGB | Result |
|---|---|---|
| Old (symmetric) | `(126, 92, 120)` — blue channel spikes ~+45 | magenta wash (blink) |
| New (asymmetric, this PR) | `(120, 93, 75)` — natural warm blend | clean photo-to-photo crossfade |

### Before / after (midpoint of the same banner switch)

<!-- Drag these into the PR on GitHub:
       Before: /tmp/issue1010_before_blink.png
       After:  /tmp/issue1010_after_fixed.png -->

**Before (blink):** _attach `issue1010_before_blink.png`_

**After (fixed):** _attach `issue1010_after_fixed.png`_

## Scope / risk

- One file, transition-timing only — no markup, no JS, no contrast changes.
- `prefers-reduced-motion` path preserved (instant cut, no crossfade).
- Affects every `carousel-fade` carousel (home, project gallery, project pages) — all benefit identically.

## Testing notes
I visually verified this works but not taking a video.
