### PR TITLE
Fix "Only my PhD advisees" filter on view-project-people (#1325)

### DIFF
--- a/website/admin/utils.py
+++ b/website/admin/utils.py
@@ -16,7 +16,7 @@ from website.models import Person, Position
 from website.models.position import Title
 
 
-def get_active_professors_queryset(prioritized_name=("Jon", "Froehlich")):
+def get_active_professors_queryset(prioritized_name=Person.DIRECTOR_NAME):
     """
     Build a queryset of currently active professors, optionally prioritizing a specific person.
 

--- a/website/models/person.py
+++ b/website/models/person.py
@@ -102,9 +102,33 @@ def get_upload_to_for_person_easter_egg(person, original_filename, force_unique=
 class Person(models.Model):
     UPLOAD_DIR = 'person/' # relative path
 
+    # The Makeability Lab has exactly one director/founder for its lifetime:
+    # Jon Froehlich. We identify him by name because that is the real invariant —
+    # he holds a professor title (not a "Director" position), so there is no
+    # title- or flag-based marker to key off of. This is the single source of
+    # truth for "who is the director"; see get_director() and #1284.
+    DIRECTOR_NAME = ("Jon", "Froehlich")
+
     @staticmethod  # use as decorator
     def get_thumbnail_size_as_str():
         return f"{PERSON_THUMBNAIL_SIZE[0]}x{PERSON_THUMBNAIL_SIZE[1]}"
+
+    @classmethod
+    def get_director(cls):
+        """
+        Returns the lab director/founder Person (Jon Froehlich), or None if that
+        Person is not in the database yet.
+
+        Resolved from :attr:`DIRECTOR_NAME` rather than a position title or flag
+        because the lab has a single director for its lifetime. Use this anywhere
+        the director needs to be identified (e.g. the is_director flag and the
+        "Only my PhD advisees" filter) so the answer cannot disagree between call
+        sites.
+        """
+        first, last = cls.DIRECTOR_NAME
+        return cls.objects.filter(
+            first_name__iexact=first, last_name__iexact=last
+        ).first()
 
     first_name = models.CharField(max_length=40)
     middle_name = models.CharField(max_length=50, blank=True, null=True)

--- a/website/templates/website/view_project_people.html
+++ b/website/templates/website/view_project_people.html
@@ -565,9 +565,15 @@ State is persisted via URL parameters for easy sharing and bookmarking.
           filtered = filtered.filter(person => person.role !== 'Collaborator');
         }
 
-        // Apply "only my PhD advisees" filter
+        // Apply "only my PhD advisees" filter.
+        // The `last_name === 'Saugstad'` clause is a deliberate special case, not
+        // a bug: Mikey Saugstad was Jon's MS student at UMD and chose not to pursue
+        // a PhD, but has since been the primary/only lead engineer on Project
+        // Sidewalk. He isn't a PhD advisee by the formal rule (server-side
+        // is_phd_advisee), so we include him here explicitly for acknowledgment
+        // grids. Revisit if he ever leaves the lab or another Saugstad joins.
         if (state.onlyMyAdvisees) {
-          filtered = filtered.filter(person => 
+          filtered = filtered.filter(person =>
             person.is_phd_advisee || person.last_name === 'Saugstad'
           );
         }

--- a/website/tests/test_view_project_people.py
+++ b/website/tests/test_view_project_people.py
@@ -5,8 +5,8 @@ Regression tests for the internal "view project people" page
 This page builds a JSON payload of every Person plus per-project role data and
 renders an entirely client-side grid (used to generate acknowledgment slides for
 talks). These tests lock the contract of that payload — project-role aggregation,
-director identification (by ``Title.DIRECTOR`` position), PhD-advisee flagging, and
-the publication indicators — so the view can be refactored safely.
+director identification (by name, via ``Person.get_director()``), PhD-advisee
+flagging, and the publication indicators — so the view can be refactored safely.
 """
 
 import json
@@ -66,10 +66,11 @@ class ViewProjectPeopleTests(DatabaseTestCase):
         self.assertEqual(roles["TestProj"]["start_date"], "2020-01-01")
         self.assertEqual(roles["TestProj"]["end_date"], "2020-12-31")
 
-    def test_director_flagged_by_title(self):
-        """is_director is true for whoever holds a Title.DIRECTOR position."""
-        director = self.make_person(first_name="Dee", last_name="Rector")
-        self._add_position(director, Title.DIRECTOR, date(2010, 1, 1))
+    def test_director_flagged_by_name(self):
+        """is_director is true only for the canonical director (Person.get_director())."""
+        first, last = Person.DIRECTOR_NAME
+        director = self.make_person(first_name=first, last_name=last)
+        self._add_position(director, Title.FULL_PROF, date(2010, 1, 1))
         other = self.make_person(first_name="Reg", last_name="Ular")
         self._add_position(other, Title.PHD_STUDENT, date(2020, 1, 1))
 
@@ -77,13 +78,38 @@ class ViewProjectPeopleTests(DatabaseTestCase):
         self.assertTrue(people[director.id]["is_director"])
         self.assertFalse(people[other.id]["is_director"])
 
+    def test_director_resolved_when_holding_professor_title(self):
+        """
+        Regression for #1284: in production the lab director holds a professor
+        title (not a ``Title.DIRECTOR`` position), and other people hold professor
+        titles too (collaborators). The director — and therefore the PhD-advisee
+        set the "Only my PhD advisees" filter relies on — must still resolve to the
+        canonical director and no one else.
+        """
+        # Another professor who is not the director and must not be flagged.
+        other_prof = self.make_person(first_name="Alice", last_name="Collaborator")
+        self._add_position(other_prof, Title.FULL_PROF, date(2010, 1, 1))
+
+        first, last = Person.DIRECTOR_NAME
+        director = self.make_person(first_name=first, last_name=last)
+        self._add_position(director, Title.FULL_PROF, date(2010, 1, 1))
+
+        advisee = self.make_person(first_name="Phd", last_name="Student")
+        self._add_position(advisee, Title.PHD_STUDENT, date(2022, 1, 1), advisor=director)
+
+        _, people = self._get_people_by_id()
+        self.assertTrue(people[director.id]["is_director"])
+        self.assertFalse(people[other_prof.id]["is_director"])
+        self.assertTrue(people[advisee.id]["is_phd_advisee"])
+
     def test_phd_advisee_logic_matches_model(self):
         """
         is_phd_advisee mirrors Person.is_phd_advisee_of: current advisee -> true,
         past advisee without dissertation -> false, past advisee with one -> true.
         """
-        director = self.make_person(first_name="Dee", last_name="Rector")
-        self._add_position(director, Title.DIRECTOR, date(2010, 1, 1))
+        first, last = Person.DIRECTOR_NAME
+        director = self.make_person(first_name=first, last_name=last)
+        self._add_position(director, Title.FULL_PROF, date(2010, 1, 1))
 
         current = self.make_person(first_name="Cur", last_name="Rent")
         self._add_position(current, Title.PHD_STUDENT, date(2022, 1, 1), advisor=director)

--- a/website/views/view_project_people.py
+++ b/website/views/view_project_people.py
@@ -236,12 +236,10 @@ def view_project_people(request):
     """
     today = date.today()
 
-    # The lab director is identified by their Title.DIRECTOR position. Both the
-    # is_director flag and the PhD-advisee check derive from this single Person so
-    # they cannot disagree.
-    director = (
-        Person.objects.filter(position__title=Title.DIRECTOR).distinct().first()
-    )
+    # The lab director drives both the is_director flag and the PhD-advisee check.
+    # Person.get_director() is the single source of truth, so the two flags cannot
+    # disagree (#1284).
+    director = Person.get_director()
     director_id = director.id if director else None
     phd_advisee_ids = _build_phd_advisee_ids(director)
 


### PR DESCRIPTION
Fixes #1325.

## Problem

The **"Only my PhD advisees"** toggle on the internal `/view-project-people/` page showed no advisees (only Mikey Saugstad, via a pre-existing hardcoded template special-case).

## Root cause

The #1284 refactor resolved the lab director with:

```python
director = Person.objects.filter(position__title=Title.DIRECTOR).distinct().first()
```

But Jon holds a **professor** title, not a `Title.DIRECTOR` position (`get_prof_titles()` excludes `DIRECTOR`; PhD students' `advisor` FK points to Jon, which requires a professor title). So the lookup matched nobody → `director` was `None` → `_build_phd_advisee_ids()` returned an empty set → every `is_phd_advisee` was `false`. The existing tests passed only because they fabricated the director *with* a `Title.DIRECTOR` position — baking in the wrong assumption.

## Fix

The Makeability Lab has exactly one director/founder for its lifetime (Jon Froehlich), so identify him by name in one canonical place:

- **`Person.DIRECTOR_NAME` + `Person.get_director()`** — single source of truth.
- **`view_project_people`** uses `Person.get_director()`; both the `is_director` flag and the advisee check derive from it, so they can't disagree.
- **`website/admin/utils.py`** reads the same `Person.DIRECTOR_NAME` constant, removing a second independent hardcoding of the name.
- **Tests:** added a regression test reproducing the production scenario (director holds a professor title, other professors exist); updated the two tests that fabricated a `Title.DIRECTOR` director to use the canonical director.

## Testing

- `python manage.py test website --settings=makeabilitylab.settings_test` → all 212 tests pass.
- The new regression test fails on the pre-fix code (`False is not true`) and passes with the fix.

## Notes

- No UI/markup change, so no a11y impact; the JSON payload contract is unchanged.
- The template's `person.last_name === 'Saugstad'` special-case is intentional and is now documented in place (it predates this bug): Mikey was Jon's MS student at UMD, chose not to pursue a PhD, and has since been the primary/only lead engineer on Project Sidewalk, so he's included in the acknowledgment view despite not being a PhD advisee by the formal rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)