### PR TITLE
Remove one-shot prod merge from docker-entrypoint.sh (#1275)

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -116,18 +116,7 @@ echo "******************************************"
 python manage.py backfill_project_visibility
 
 echo "****************** STEP 4.8/5: docker-entrypoint.sh ************************"
-echo "4.8 Running 'python manage.py merge_duplicate_people' (PROD only) to consolidate duplicate Person records (#1275)"
-echo "******************************************"
-# ONE-SHOT (remove after the first prod run confirms in /logs). Gated to PROD
-# because dedup_decisions.csv is keyed by production ids; the merge command also
-# refuses name-mismatched pairs as a backstop. Idempotent, so a lingering run is
-# a harmless no-op once the duplicates are already merged.
-if [ "$DJANGO_ENV" = "PROD" ]; then
-  python manage.py merge_duplicate_people --decisions dedup_decisions.csv --apply
-fi
-
-echo "****************** STEP 4.9/5: docker-entrypoint.sh ************************"
-echo "4.9 Running 'python manage.py recompute_url_names' to de-collide historical url_names (#1206)"
+echo "4.8 Running 'python manage.py recompute_url_names' to de-collide historical url_names (#1206)"
 echo "******************************************"
 python manage.py recompute_url_names
 


### PR DESCRIPTION
Follow-up to #1327. The 2.11.0 prod deploy ran the one-shot `merge_duplicate_people --apply`; prod Data Health now reports **0 url_name collisions** and **2 duplicate-people rows** (the intended `jasminezhang` namesakes, ids 840/869 — distinct, reachable URLs).

This removes the PROD-gated one-shot from `docker-entrypoint.sh` so future prod restarts don't re-run it (it's idempotent, so this is hygiene, not a fix). `recompute_url_names` remains in the entrypoint (renumbered to step 4.8) as the durable de-collision pass.

`merge_duplicate_people`, `dedup_decisions.csv` (kept as the audit record of what was merged), and the regression tests stay in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)