### PR TITLE
feat(seo): smarter meta-description fallbacks; trim over-long defaults (2.12.1, #1142/#1324)

### DIFF
--- a/makeabilitylab/settings.py
+++ b/makeabilitylab/settings.py
@@ -72,8 +72,8 @@ else:
     ALLOWED_HOSTS = ['*']
 
 # Makeability Lab Global Variables, including Makeability Lab version
-ML_WEBSITE_VERSION = "2.12.0" # Keep this updated with each release and also change the short description below
-ML_WEBSITE_VERSION_DESCRIPTION = "Minor: site-wide SEO / social-sharing metadata overhaul (#1236, #1142, #1324). Centralized per-page Open Graph + Twitter Card tags with https URLs behind the TLS proxy (fixes #1236 via a site_scheme context processor), self-referential canonical links, distinct per-page meta descriptions, and schema.org JSON-LD (Organization on home, Person w/ sameAs on member pages, NewsArticle on news). Adds ORCID + Google Scholar fields to Person. IT follow-up #1329 (SECURE_PROXY_SSL_HEADER) would supersede the site_scheme workaround."
+ML_WEBSITE_VERSION = "2.12.1" # Keep this updated with each release and also change the short description below
+ML_WEBSITE_VERSION_DESCRIPTION = "Patch: tighten meta descriptions (#1142/#1324). Home now uses a concise description mirroring the hero blurb; projects without a one-line summary fall back to a truncated About instead of the generic lab boilerplate; the last-resort default is trimmed to ~135 chars. Reduces duplicate/over-long descriptions flagged by social/OG inspectors. Template/view-only — no schema change."
 DATE_MAKEABILITYLAB_FORMED = datetime.date(2012, 1, 1)  # Date Makeability Lab was formed
 MAX_BANNERS = 7 # Maximum number of banners on a page
 

--- a/website/templates/website/base.html
+++ b/website/templates/website/base.html
@@ -79,7 +79,7 @@ TEMPLATE BLOCKS:
   ============================================================================
   {% endcomment %}
   {% with meta_title=page_meta.title|default:"Makeability Lab" og_type=page_meta.og_type|default:"website" canonical_path=page_meta.canonical_path|default:request.path %}
-  {% firstof page_meta.description "The Makeability Lab is an advanced research lab in Human-Computer Interaction and AI directed by Professor Jon E. Froehlich at University of Washington's Allen School of Computer Science." as meta_description %}
+  {% firstof page_meta.description "The Makeability Lab is an advanced research lab in Human-AI directed by Prof. Jon E. Froehlich at UW's Allen School of Computer Science." as meta_description %}
   <meta name="description" content="{{ meta_description }}">
   <link rel="canonical" href="{{ site_scheme }}://{{ request.get_host }}{{ canonical_path }}">
 

--- a/website/tests/test_page_metadata.py
+++ b/website/tests/test_page_metadata.py
@@ -205,6 +205,45 @@ class JsonLdTests(DatabaseTestCase):
         self.assertEqual(data["headline"], "Pwn </script><b>x</b>")  # round-trips
 
 
+class DescriptionFallbackTests(DatabaseTestCase):
+    """Distinct, length-bounded descriptions instead of the generic boilerplate
+    (#1142/#1324): home mirrors the hero blurb; summary-less projects use About."""
+
+    def _meta_description(self, resp):
+        m = re.search(r'name="description" content="([^"]*)"', resp.content.decode())
+        return m.group(1) if m else None
+
+    def test_home_uses_distinct_hero_description(self):
+        resp = self.client.get(reverse("website:index"))
+        desc = self._meta_description(resp)
+        self.assertIn("advanced research lab in Human-AI, directed by", desc)
+        self.assertLessEqual(len(desc), 160)
+        # not the old generic boilerplate
+        self.assertNotIn("Human-Computer Interaction and AI directed by Professor", desc)
+
+    def test_project_without_summary_falls_back_to_about(self):
+        p = self.make_project(
+            name="GlassEar", short_name="glassear", is_visible=True,
+            start_date=date(2021, 1, 1), summary="",
+            about="<p>GlassEar is a wearable sound-awareness display for d/Deaf users.</p>",
+        )
+        resp = self.client.get(reverse("website:project", args=[p.short_name]))
+        desc = self._meta_description(resp)
+        self.assertIn("GlassEar is a wearable sound-awareness display", desc)
+        self.assertLessEqual(len(desc), 160)
+
+    def test_project_without_summary_or_about_uses_trimmed_default(self):
+        p = self.make_project(
+            name="Empty Proj", short_name="emptyproj", is_visible=True,
+            start_date=date(2021, 1, 1), summary="", about="",
+        )
+        resp = self.client.get(reverse("website:project", args=[p.short_name]))
+        desc = self._meta_description(resp)
+        # last-resort generic default — present but trimmed
+        self.assertIn("Makeability Lab", desc)
+        self.assertLessEqual(len(desc), 160)
+
+
 class PageMetadataSchemeTests(DatabaseTestCase):
     """site_scheme keys off DJANGO_ENV, not DEBUG. The test server runs DEBUG=True
     behind the same TLS proxy as prod, so a DEBUG-based check would emit http://

--- a/website/views/index.py
+++ b/website/views/index.py
@@ -79,6 +79,14 @@ def index(request):
                'sponsors': sponsors,
                'debug': settings.DEBUG}
 
+    # Distinct home-page description, mirroring the hero "About Us" blurb next to
+    # the animated logo (index.html). Concise (~155 chars) so it isn't truncated
+    # in search/social previews, and not the generic fallback (#1142/#1324).
+    home_description = ("The Makeability Lab is an advanced research lab in Human-AI, "
+                        "directed by Prof. Jon E. Froehlich in UW's Allen School of "
+                        "Computer Science.")
+    context['page_meta'] = {'description': home_description}
+
     # schema.org Organization JSON-LD (home page) — helps Google build a
     # knowledge panel for "Makeability Lab" (#1142/#1324). Rendered by the
     # jsonld block in base.html.
@@ -89,10 +97,7 @@ def index(request):
         "url": absolute_url(request, "/"),
         "logo": absolute_url(request, static(
             "website/img/logos/makelab_logo_v3_white_with_colors_and_text_og_image_ratio_1200w.png")),
-        "description": ("The Makeability Lab is an advanced research lab in "
-                        "Human-Computer Interaction and AI directed by Professor "
-                        "Jon E. Froehlich at the University of Washington's Allen "
-                        "School of Computer Science."),
+        "description": home_description,
         "parentOrganization": {
             "@type": "CollegeOrUniversity",
             "name": ("Paul G. Allen School of Computer Science & Engineering, "

--- a/website/views/project.py
+++ b/website/views/project.py
@@ -121,7 +121,10 @@ def project(request, project_name):
     # /projects/ alias to one indexable URL.
     context['page_meta'] = {
         'title': project.name,
-        'description': meta_description(project.summary),
+        # Prefer the one-line summary; fall back to the (HTML) About text,
+        # stripped + truncated. Gives summary-less projects a distinct
+        # description instead of the generic lab boilerplate (#1142/#1324).
+        'description': meta_description(project.summary or project.about),
         'canonical_path': reverse('website:project', args=[project.short_name]),
     }
 


### PR DESCRIPTION
Follow-up to the 2.12.0 SEO work, addressing the one actionable warning from
opengraph.xyz (over-long / generic descriptions on fallback pages). Verified live:
`/projects/` (144), `/people/` (145), `/member/jonfroehlich/` (160) were already
fine; only the **187-char generic fallback** (home + summary-less projects like
`/project/sidewalk/`) was flagged.

## Changes
- **Home** now uses a concise (~135 char) description mirroring the hero "About Us"
  blurb next to the animated logo (instead of the shared generic boilerplate). Reused
  for the Organization JSON-LD `description`.
- **Projects without a `summary`** fall back to the project's **`about`** text
  (stripped + truncated to 160) — so each summary-less project gets a *distinct*
  description rather than identical boilerplate (directly reduces the duplicate-content
  signal behind #1142).
- **Trimmed** the last-resort generic default to ~135 chars.

## Intentionally NOT changed
opengraph.xyz's "missing headline in image" / "missing CTA in image" warnings are
engagement-marketing heuristics (text/CTA baked into the share-image pixels). That's
inappropriate for an academic research lab and isn't a correctness or SEO issue; the
`og:image` itself is valid (1200×630, alt text, https).

## Testing
- `DescriptionFallbackTests`: home uses the distinct hero description (≤160, not the
  generic); summary-less project uses About; summary+about-less project uses the
  trimmed default (≤160).
- Full suite: **270 pass, 1 skipped**.
- Version → **2.12.1**. Template/view-only — **no schema change, no migration / deploy blip**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)