### PR TITLE
feat(seo): add lastmod to static sitemap listing pages (#1324)

### DIFF
--- a/website/sitemaps.py
+++ b/website/sitemaps.py
@@ -24,7 +24,17 @@ listing), so they are covered by the static sitemap and not enumerated here.
 from django.contrib.sitemaps import Sitemap
 from django.urls import reverse
 
-from website.models import Project, Person, News
+from website.models import Project, Person, News, Publication, Award
+
+
+def _latest(model, field):
+    """Return the most recent non-null value of ``field`` across ``model``, or None."""
+    return (
+        model.objects.filter(**{f"{field}__isnull": False})
+        .order_by(f"-{field}")
+        .values_list(field, flat=True)
+        .first()
+    )
 
 
 class _HttpsSitemap(Sitemap):
@@ -61,6 +71,39 @@ class StaticViewSitemap(_HttpsSitemap):
 
     def location(self, item):
         return reverse(item)
+
+    def lastmod(self, item):
+        """
+        Most-recent content date for each listing page, so the sitemap signals
+        when a section last changed (helps crawlers prioritize re-crawls).
+
+        Returns ``None`` for an empty section; the framework then simply omits
+        ``<lastmod>`` for that URL. Some sections expose a ``date`` (plain date)
+        and people a datetime — Django's ``get_latest_lastmod`` catches the
+        resulting mixed-type ``max()`` and just drops the sitemap-level lastmod,
+        so this is safe.
+        """
+        if item == "website:people":
+            return _latest(Person, "bio_datetime_modified")
+        if item == "website:publications":
+            return _latest(Publication, "date")
+        if item == "website:projects":
+            return _latest(Project, "updated")
+        if item == "website:awards":
+            return _latest(Award, "date")
+        if item == "website:news_listing":
+            return _latest(News, "date")
+        if item == "website:index":
+            # Home page surfaces recent content across sections; use the most
+            # recent of news, publications, and project updates.
+            candidates = [
+                _latest(News, "date"),
+                _latest(Publication, "date"),
+                _latest(Project, "updated"),
+            ]
+            candidates = [c for c in candidates if c is not None]
+            return max(candidates) if candidates else None
+        return None
 
 
 class ProjectSitemap(_HttpsSitemap):

--- a/website/tests/test_sitemap.py
+++ b/website/tests/test_sitemap.py
@@ -60,6 +60,19 @@ class SitemapTests(DatabaseTestCase):
         body = self.client.get("/sitemap.xml").content.decode()
         self.assertIn(f"/news/{news.slug}/", body)
 
+    def test_static_listing_pages_have_lastmod(self):
+        # The listing pages should advertise a <lastmod> sourced from their
+        # most-recent content, not be the only entries with none. Create a news
+        # item so the news/home/listing sections are non-empty.
+        self.make_news_item(title="Dated News")
+        body = self.client.get("/sitemap.xml").content.decode()
+        # Pull the <url> block for the /news/ listing and assert it carries a
+        # <lastmod>. (Detail-page news URLs look like /news/<slug>/.)
+        url_blocks = re.findall(r"<url>(.*?)</url>", body, re.DOTALL)
+        listing = [b for b in url_blocks if re.search(r"<loc>[^<]*/news/</loc>", b)]
+        self.assertTrue(listing, "expected a /news/ listing entry in the sitemap")
+        self.assertIn("<lastmod>", listing[0])
+
     def test_sitemap_uses_https_scheme(self):
         # Apache proxies to Django over plain HTTP, so without a pinned
         # protocol the <loc> URLs would be http:// and only 302-redirect to


### PR DESCRIPTION
## What

Adds `<lastmod>` to the **static listing pages** in the sitemap (home, people, publications, projects, awards, news). The per-object sitemaps (projects/people/news) already emitted `<lastmod>`; the listing pages did not, so crawlers got no re-crawl signal for the listings.

Each listing's `lastmod` is sourced from its section's most-recent content date:
- people → latest `Person.bio_datetime_modified`
- publications → latest `Publication.date`
- projects → latest `Project.updated`
- awards → latest `Award.date`
- news → latest `News.date`
- home → most recent of news / publications / project updates

Empty sections return `None`, so the framework simply omits `<lastmod>` for them. Mixed date/datetime across sections is safe — Django's `get_latest_lastmod` catches the mixed-type `max()` and drops only the sitemap-index lastmod.

## Why

Closes the **"sitemap `lastmod` completeness polish"** item from #1324. This is the last concrete on-page-SEO task in that issue; see #1324 for the full wrap-up (the `ScholarlyArticle` JSON-LD item is being dropped, and the `SECURE_PROXY_SSL_HEADER` follow-up lives in #1329).

## Test

Added `test_static_listing_pages_have_lastmod` to `website/tests/test_sitemap.py`. Full sitemap suite passes (8 tests):

```
docker exec makeabilitylabwebsite-website-1 python manage.py test website.tests.test_sitemap --settings=makeabilitylab.settings_test
```

No UI changes (XML output only), so no a11y/screenshot impact.

Refs #1324

🤖 Generated with [Claude Code](https://claude.com/claude-code)