### PR TITLE
fix(ui): wrap member section nav 2-up on mobile (#1331)

### DIFF
--- a/website/static/website/css/member.css
+++ b/website/static/website/css/member.css
@@ -651,6 +651,17 @@
   outline-offset: var(--focus-ring-offset);
 }
 
+/* On phones, pin each link to ~half the row so the four sections wrap a clean
+   2-up grid (Projects/Papers, then Videos/Talks) instead of orphaning "Talks"
+   onto its own line (#1331). flex-wrap + justify-content:center (above) center
+   a lone last item for members who have only three sections. */
+@media (max-width: 576px) {
+  .member-section-nav-list li {
+    flex: 0 1 calc(50% - var(--space-2));
+    text-align: center;
+  }
+}
+
 /* Anchor jumps (and scroll-spy) should land the heading below the fixed navbar
    AND this sticky nav, not underneath them. */
 .person-section {


### PR DESCRIPTION
## Summary

Fixes #1331. On phones, the sticky `member-section-nav-list` (Projects / Papers / Videos / Talks) wrapped unevenly, orphaning **Talks** onto its own line.

This pins each link to ~half-row width below the `576px` phone breakpoint, so the four sections wrap a clean 2-up grid:

```
Projects (8/8)    Papers (6/106)
Videos (6/14)     Talks (8/95)
```

## Why this approach

- **vs. forcing one line:** at ~320px that needs tiny text or horizontal scroll and shrinks tap targets. The 2-up layout keeps links comfortably tappable (consistent with the WCAG 2.5.5 touch-target care elsewhere in this file).
- **vs. CSS Grid:** reusing the list's existing `flex-wrap` + `justify-content: center` means a member with only **three** sections gets the lone last link *centered* on row 2 instead of left-orphaned.
- `576px` matches this file's existing "phone" breakpoint (the mobile grid caps use the same).

## Changes

- `website/static/website/css/member.css`: one `@media (max-width: 576px)` block (CSS only — no template/JS change).

## Testing

CSS-only layout change; no automated tests apply. Verified the wrap math (`2 × calc(50% - gap) + gap = 100% - gap`, no overflow). No before/after screenshot per maintainer request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)