### PR TITLE
Enable SECURE_PROXY_SSL_HEADER on TEST/PROD (#1329)

### DIFF
--- a/makeabilitylab/settings.py
+++ b/makeabilitylab/settings.py
@@ -71,6 +71,20 @@ if config.has_option('Django', 'ALLOWED_HOSTS'):
 else:
     ALLOWED_HOSTS = ['*']
 
+# Trust the X-Forwarded-Proto header from UW CSE's TLS-terminating Apache proxy so
+# request.scheme / request.is_secure() report the real (https) scheme (#1329).
+#
+# The deployed Django container is reached over plain HTTP from Apache, so without
+# this Django thinks every request is http even though visitors arrive over https.
+# This is ONLY safe because the proxy is trusted: Apache sets X-Forwarded-Proto and
+# the backend binds to the host's loopback only, so a client can't reach Django
+# directly to spoof the header (confirmed with UW CSE IT). Gated to the deployed
+# environments — in local dev there is no such proxy, so we must NOT trust the
+# header (a direct client could forge it). Supersedes the in-app site_scheme
+# workaround from #1236, which we keep for now and remove once verified on -test.
+if DJANGO_ENV in ('PROD', 'TEST'):
+    SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
 # Makeability Lab Global Variables, including Makeability Lab version
 ML_WEBSITE_VERSION = "2.12.1" # Keep this updated with each release and also change the short description below
 ML_WEBSITE_VERSION_DESCRIPTION = "Patch: tighten meta descriptions (#1142/#1324). Home now uses a concise description mirroring the hero blurb; projects without a one-line summary fall back to a truncated About instead of the generic lab boilerplate; the last-resort default is trimmed to ~135 chars. Reduces duplicate/over-long descriptions flagged by social/OG inspectors. Template/view-only — no schema change."


### PR DESCRIPTION
Closes #1329.

## What

Adds, gated to the deployed environments:

```python
if DJANGO_ENV in ('PROD', 'TEST'):
    SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
```

Behind UW CSE's TLS-terminating Apache proxy the Django container is reached over plain HTTP, so `request.scheme` reported `http` and `request.is_secure()` was `False` even though visitors arrive over HTTPS. This tells Django to trust the proxy's `X-Forwarded-Proto` header as the real scheme.

## Why it's safe (and why gated)

- **UW CSE IT (Jason Howe) confirmed** Apache now sets `X-Forwarded-Proto: https` on both **test** and **prod**.
- The Django backend binds to the host's **loopback only**, so a client can't reach it directly to forge the header.
- **Gated to `DJANGO_ENV in (PROD, TEST)`** — local dev has no trusted proxy, so we must not trust a client-supplied header there. Mirrors the `DJANGO_ENV`-keyed pattern from #1236.

## Scope

This is the framework-level fix behind #1236. The in-app `site_scheme` workaround (context processor + `website/utils/metadata.py` + templates) is **left in place** for now as a redundant safety net; it will be removed in a follow-up once `request.is_secure()` is verified correct on `-test`.

## Testing

No new automated test: the behavior is Django framework internals (`SECURE_PROXY_SSL_HEADER`) gated by an import-time env var, so a regression test would only re-test Django. Existing `test_page_metadata.py` `site_scheme` tests remain green (workaround untouched).

Manual verification after merge → deploy to `-test`:
- Confirm canonical / `og:url` tags still render `https://` (no regression).
- Confirm `request.is_secure()` is now `True` behind the proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)