### PR TITLE
Exclude django-debug-toolbar from the Pa11y CI scan (#1278)

### DIFF
--- a/.pa11yci.ci.json
+++ b/.pa11yci.ci.json
@@ -6,10 +6,10 @@
     "chromeLaunchConfig": {
       "args": ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage"]
     },
-    "hideElements": "#js-toc",
+    "hideElements": "#js-toc, #djDebug",
     "ignore": []
   },
-  "_comment": "CI variant of .pa11yci.json (#1278 item 6). The local-dev config targets the docker-compose 'website:8000' host with the maintainer's real DB snapshot (jonfroehlich, sidewalk, ...). CI has no snapshot, so this config targets a native runserver on localhost:8000 seeded with deterministic demo content via `manage.py seed_demo_projects` + `seed_demo_news`. Keep the two URL lists in sync with what those seed commands create.",
+  "_comment": "CI variant of .pa11yci.json (#1278 item 6). The local-dev config targets the docker-compose 'website:8000' host with the maintainer's real DB snapshot (jonfroehlich, sidewalk, ...). CI has no snapshot, so this config targets a native runserver on localhost:8000 seeded with deterministic demo content via `manage.py seed_demo_projects` + `seed_demo_news`. Keep the two URL lists in sync with what those seed commands create. hideElements hides #djDebug because CI runs DEBUG=True (so runserver serves media), which injects the django-debug-toolbar; its markup is dev-only and was ~76% of the reported violations, so we exclude it to keep the baseline representative of production.",
   "urls": [
     "http://localhost:8000/",
     "http://localhost:8000/people/",


### PR DESCRIPTION
## What & why

Follow-up to the Pa11y CI job (#1278 item 6, merged in #1340).

The `a11y` job runs `runserver` with `DEBUG=True` (needed so it serves media/static while pa11y scans). That injects **django-debug-toolbar** into every page — and its markup was **~76% of the reported violations**: 126 "form element needs a visible label" (the toolbar's panel checkboxes) + 42 color-contrast findings. None of that exists in production (`DEBUG=False`, no toolbar), so it made the baseline misleading.

**Fix:** add `#djDebug` (the toolbar's root container, confirmed in `debug_toolbar/templates/debug_toolbar/base.html`) to `hideElements` — the same pa11y mechanism already used for `#js-toc`.

After this, the scan reports only real site violations (~54, across 4 types). Tracking issue for those to follow.

## Scope
One-line config change. No app/schema change; report-only job stays report-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)