### PR TITLE
Remove site_scheme workaround; rely on request.scheme (closes #1329)

### DIFF
--- a/makeabilitylab/settings.py
+++ b/makeabilitylab/settings.py
@@ -281,7 +281,6 @@ TEMPLATES = [
                 'django.contrib.messages.context_processors.messages',
                 'website.context_processors.recent_news',
                 'website.context_processors.admin_version_info',
-                'website.context_processors.site_scheme',
             ],
         },
     },

--- a/website/context_processors.py
+++ b/website/context_processors.py
@@ -9,7 +9,6 @@
 
 from .models import News
 from django.conf import settings
-from website.utils.metadata import site_scheme as metadata_site_scheme
 
 def recent_news(request):
     """ context processors returning recent news """
@@ -17,19 +16,6 @@ def recent_news(request):
     news_items = News.objects.order_by('-date')[:news_items_num]
 
     return { 'recent_news': news_items, }
-
-def site_scheme(request):
-    """
-    Expose the canonical URL scheme (``http`` / ``https``) to every template, so
-    templates can build absolute URLs as
-    ``{{ site_scheme }}://{{ request.get_host }}{{ path }}`` that aren't ``http://``
-    behind UW CSE's TLS-terminating proxy (issue #1236).
-
-    Delegates to :func:`website.utils.metadata.site_scheme` (the single source of
-    truth, keyed on ``DJANGO_ENV``) so the scheme used by view-built JSON-LD URLs
-    and template-built canonical/OG URLs can't drift.
-    """
-    return {'site_scheme': metadata_site_scheme(request)}
 
 def admin_version_info(request):
     """

--- a/website/templates/website/base.html
+++ b/website/templates/website/base.html
@@ -69,8 +69,9 @@ TEMPLATE BLOCKS:
   by <meta name="description">, og:description, and twitter:description (no
   duplication).
 
-  Absolute URLs use {{ site_scheme }} (https on the servers, http in local dev)
-  so they don't advertise http:// behind the TLS proxy — see #1236.
+  Absolute URLs use request.scheme (https on the servers, http in local dev).
+  It's correct behind the TLS proxy because SECURE_PROXY_SSL_HEADER trusts the
+  proxy's X-Forwarded-Proto header — see #1329 (which replaced the #1236 fix).
 
   Detail templates customize via:
     {% block social_image %} — og:image + twitter:image (default: lab logo)
@@ -81,7 +82,7 @@ TEMPLATE BLOCKS:
   {% with meta_title=page_meta.title|default:"Makeability Lab" og_type=page_meta.og_type|default:"website" canonical_path=page_meta.canonical_path|default:request.path %}
   {% firstof page_meta.description "The Makeability Lab is an advanced research lab in Human-AI directed by Prof. Jon E. Froehlich at UW's Allen School of Computer Science." as meta_description %}
   <meta name="description" content="{{ meta_description }}">
-  <link rel="canonical" href="{{ site_scheme }}://{{ request.get_host }}{{ canonical_path }}">
+  <link rel="canonical" href="{{ request.scheme }}://{{ request.get_host }}{{ canonical_path }}">
 
   <!-- Open Graph (Facebook, LinkedIn, Slack, Bluesky, …) -->
   <meta property="og:site_name" content="Makeability Lab">
@@ -89,11 +90,11 @@ TEMPLATE BLOCKS:
   <meta property="og:title" content="{{ meta_title }}">
   <meta property="og:type" content="{{ og_type }}">
   <meta property="og:description" content="{{ meta_description }}">
-  <meta property="og:url" content="{{ site_scheme }}://{{ request.get_host }}{{ canonical_path }}">
+  <meta property="og:url" content="{{ request.scheme }}://{{ request.get_host }}{{ canonical_path }}">
   {% block social_image %}
-  <meta property="og:image" content="{{ site_scheme }}://{{ request.get_host }}{% static 'website/img/logos/makelab_logo_v3_white_with_colors_and_text_og_image_ratio_1200w.png' %}">
+  <meta property="og:image" content="{{ request.scheme }}://{{ request.get_host }}{% static 'website/img/logos/makelab_logo_v3_white_with_colors_and_text_og_image_ratio_1200w.png' %}">
   <meta property="og:image:alt" content="Makeability Lab logo">
-  <meta name="twitter:image" content="{{ site_scheme }}://{{ request.get_host }}{% static 'website/img/logos/makelab_logo_v3_white_with_colors_and_text_og_image_ratio_1200w.png' %}">
+  <meta name="twitter:image" content="{{ request.scheme }}://{{ request.get_host }}{% static 'website/img/logos/makelab_logo_v3_white_with_colors_and_text_og_image_ratio_1200w.png' %}">
   {% endblock social_image %}
   {% block meta_extra %}{% endblock %}
 

--- a/website/templates/website/member.html
+++ b/website/templates/website/member.html
@@ -56,11 +56,11 @@ CONTEXT VARIABLES:
 {% block social_image %}
 {% thumbnail person.image '1200x630' box=person.cropping crop=True upscale=True as og_img %}
 {% if og_img %}
-<meta property="og:image" content="{{ site_scheme }}://{{ request.get_host }}{{ og_img.url }}">
+<meta property="og:image" content="{{ request.scheme }}://{{ request.get_host }}{{ og_img.url }}">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta property="og:image:alt" content="{{ person.get_full_name }}">
-<meta name="twitter:image" content="{{ site_scheme }}://{{ request.get_host }}{{ og_img.url }}">
+<meta name="twitter:image" content="{{ request.scheme }}://{{ request.get_host }}{{ og_img.url }}">
 {% else %}
 {{ block.super }}
 {% endif %}

--- a/website/templates/website/news_item.html
+++ b/website/templates/website/news_item.html
@@ -48,15 +48,15 @@ CONTEXT VARIABLES:
 {% block social_image %}
 {% if news_item.image %}{% thumbnail news_item.image '1200x630' box=news_item.cropping crop=True upscale=True as og_img %}{% endif %}
 {% if og_img %}
-<meta property="og:image" content="{{ site_scheme }}://{{ request.get_host }}{{ og_img.url }}">
+<meta property="og:image" content="{{ request.scheme }}://{{ request.get_host }}{{ og_img.url }}">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta property="og:image:alt" content="{{ news_item.title }}">
-<meta name="twitter:image" content="{{ site_scheme }}://{{ request.get_host }}{{ og_img.url }}">
+<meta name="twitter:image" content="{{ request.scheme }}://{{ request.get_host }}{{ og_img.url }}">
 {% else %}
-<meta property="og:image" content="{{ site_scheme }}://{{ request.get_host }}{% static news_item.default_news_image_filename %}">
+<meta property="og:image" content="{{ request.scheme }}://{{ request.get_host }}{% static news_item.default_news_image_filename %}">
 <meta property="og:image:alt" content="{{ news_item.title }}">
-<meta name="twitter:image" content="{{ site_scheme }}://{{ request.get_host }}{% static news_item.default_news_image_filename %}">
+<meta name="twitter:image" content="{{ request.scheme }}://{{ request.get_host }}{% static news_item.default_news_image_filename %}">
 {% endif %}
 {% endblock social_image %}
 

--- a/website/templates/website/project.html
+++ b/website/templates/website/project.html
@@ -70,11 +70,11 @@ CONTEXT VARIABLES:
 {% block social_image %}
 {% thumbnail project.gallery_image 1200x630 box=project.cropping crop=True upscale=True as og_img %}
 {% if og_img %}
-<meta property="og:image" content="{{ site_scheme }}://{{ request.get_host }}{{ og_img.url }}">
+<meta property="og:image" content="{{ request.scheme }}://{{ request.get_host }}{{ og_img.url }}">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta property="og:image:alt" content="{{ project.name }}">
-<meta name="twitter:image" content="{{ site_scheme }}://{{ request.get_host }}{{ og_img.url }}">
+<meta name="twitter:image" content="{{ request.scheme }}://{{ request.get_host }}{{ og_img.url }}">
 {% else %}
 {{ block.super }}
 {% endif %}

--- a/website/tests/test_page_metadata.py
+++ b/website/tests/test_page_metadata.py
@@ -7,13 +7,13 @@ centralized metadata block in ``base.html`` (or the ``page_meta`` a view feeds
 it) is caught. They pin three things:
 
   * canonical + Open Graph + Twitter Card tags are present on every page type;
-  * absolute URLs use ``https`` behind the proxy (the #1236 fix), driven by the
-    ``site_scheme`` context processor — verified by toggling ``DEBUG``;
+  * absolute URLs follow ``request.scheme`` — https behind the proxy because
+    ``SECURE_PROXY_SSL_HEADER`` trusts the proxy's ``X-Forwarded-Proto`` header
+    (#1329, which replaced the #1236 ``site_scheme`` workaround);
   * detail pages emit distinct, per-page titles/descriptions/types rather than
     the single generic site description.
 
-See website/templates/website/base.html, website/context_processors.py, and
-website/utils/metadata.py.
+See website/templates/website/base.html and website/utils/metadata.py.
 """
 
 import json
@@ -46,15 +46,17 @@ def _position(person, title=None):
     )
 
 
-# On the servers (DJANGO_ENV TEST/PROD) site_scheme pins https — assert against
-# that (the test client's host is "testserver", auto-added to ALLOWED_HOSTS).
-# NB: DJANGO_ENV, not DEBUG — the test server runs DEBUG=True behind the proxy
-# (see PageMetadataSchemeTests for the regression that motivated this).
-@override_settings(DJANGO_ENV='PROD')
+# Absolute URLs follow request.scheme. We issue secure (https) requests to mirror
+# the deployed servers, where SECURE_PROXY_SSL_HEADER makes request.scheme https
+# behind the TLS proxy (see PageMetadataSchemeTests for the header-driven path).
+# The test client's host is "testserver", auto-added to ALLOWED_HOSTS.
 class PageMetadataHttpsTests(DatabaseTestCase):
+    # Requests are issued with secure=True so request.scheme == "https", mirroring
+    # the deployed servers where SECURE_PROXY_SSL_HEADER makes the scheme https
+    # behind the TLS proxy.
 
     def test_home_has_core_metadata(self):
-        resp = self.client.get(reverse("website:index"))
+        resp = self.client.get(reverse("website:index"), secure=True)
         self.assertEqual(resp.status_code, 200)
         # Canonical present and https.
         self.assertContains(resp, '<link rel="canonical" href="https://testserver/">')
@@ -67,7 +69,7 @@ class PageMetadataHttpsTests(DatabaseTestCase):
 
     def test_no_http_scheme_in_social_urls(self):
         """#1236: og:url / og:image / canonical must never advertise http://."""
-        resp = self.client.get(reverse("website:index"))
+        resp = self.client.get(reverse("website:index"), secure=True)
         self.assertNotContains(resp, 'property="og:url" content="http://')
         self.assertNotContains(resp, 'property="og:image" content="http://')
         self.assertNotContains(resp, 'rel="canonical" href="http://')
@@ -78,7 +80,7 @@ class PageMetadataHttpsTests(DatabaseTestCase):
             start_date=date(2020, 1, 1),
             summary="SoundWatch is a smartwatch system for sound awareness.",
         )
-        resp = self.client.get(reverse("website:project", args=[project.short_name]))
+        resp = self.client.get(reverse("website:project", args=[project.short_name]), secure=True)
         self.assertEqual(resp.status_code, 200)
         # Canonical matches the sitemap's reverse()-built URL exactly.
         canonical = "https://testserver" + reverse("website:project", args=[project.short_name])
@@ -94,7 +96,8 @@ class PageMetadataHttpsTests(DatabaseTestCase):
                                   bio="Ada researches accessible computing.")
         _position(person)
         resp = self.client.get(
-            reverse("website:member_by_name", kwargs={"member_name": person.url_name})
+            reverse("website:member_by_name", kwargs={"member_name": person.url_name}),
+            secure=True,
         )
         self.assertEqual(resp.status_code, 200)
         self.assertContains(resp, '<meta property="og:type" content="profile">')
@@ -113,7 +116,8 @@ class PageMetadataHttpsTests(DatabaseTestCase):
             content="The Makeability Lab won a best paper award at CHI.",
         )
         resp = self.client.get(
-            reverse("website:news_item_by_id", kwargs={"id": item.id})
+            reverse("website:news_item_by_id", kwargs={"id": item.id}),
+            secure=True,
         )
         self.assertEqual(resp.status_code, 200)
         self.assertContains(resp, '<meta property="og:type" content="article">')
@@ -245,25 +249,35 @@ class DescriptionFallbackTests(DatabaseTestCase):
 
 
 class PageMetadataSchemeTests(DatabaseTestCase):
-    """site_scheme keys off DJANGO_ENV, not DEBUG. The test server runs DEBUG=True
-    behind the same TLS proxy as prod, so a DEBUG-based check would emit http://
-    there (regression for the #1236 follow-up fix)."""
+    """Absolute URLs follow ``request.scheme``. Behind UW CSE's TLS-terminating
+    proxy that is https because ``SECURE_PROXY_SSL_HEADER`` trusts the proxy's
+    ``X-Forwarded-Proto`` header (#1329, which replaced the DJANGO_ENV-keyed
+    ``site_scheme`` workaround from #1236)."""
 
-    @override_settings(DJANGO_ENV='TEST', DEBUG=True)
-    def test_test_server_uses_https_even_with_debug_true(self):
-        """The crux: DJANGO_ENV=TEST + DEBUG=True must still emit https."""
-        resp = self.client.get(reverse("website:index"))
+    @override_settings(SECURE_PROXY_SSL_HEADER=("HTTP_X_FORWARDED_PROTO", "https"))
+    def test_forwarded_proto_header_drives_https(self):
+        """The deployed path: an http request carrying X-Forwarded-Proto: https
+        is treated as secure, so absolute URLs emit https — exactly what Apache
+        forwards to the container (#1329). This is the crux that the old
+        DEBUG-based check got wrong on the test server (#1236)."""
+        # Send a clean Host header too (as Apache does), so get_host() doesn't
+        # append the test client's :80 port to the now-https URL.
+        resp = self.client.get(
+            reverse("website:index"),
+            HTTP_X_FORWARDED_PROTO="https",
+            HTTP_HOST="testserver",
+        )
         self.assertContains(resp, '<link rel="canonical" href="https://testserver/">')
         self.assertContains(resp, '<meta property="og:url" content="https://testserver/">')
 
-    @override_settings(DJANGO_ENV='PROD', DEBUG=False)
-    def test_prod_uses_https(self):
-        resp = self.client.get(reverse("website:index"))
+    def test_secure_request_uses_https(self):
+        """A direct TLS request (request.scheme == https) emits https URLs."""
+        resp = self.client.get(reverse("website:index"), secure=True)
+        self.assertContains(resp, '<link rel="canonical" href="https://testserver/">')
         self.assertContains(resp, '<meta property="og:url" content="https://testserver/">')
 
-    @override_settings(DJANGO_ENV='DEBUG', DEBUG=True)
     def test_local_dev_uses_request_scheme(self):
-        """Local dev (DJANGO_ENV=DEBUG/unset over http) follows request.scheme."""
+        """Local dev over http (no proxy header) follows request.scheme — http."""
         resp = self.client.get(reverse("website:index"))
         self.assertContains(resp, '<link rel="canonical" href="http://testserver/">')
         self.assertContains(resp, '<meta property="og:url" content="http://testserver/">')

--- a/website/utils/metadata.py
+++ b/website/utils/metadata.py
@@ -11,7 +11,6 @@ See ``website/templates/website/base.html`` for how ``page_meta`` is rendered.
 
 import json
 
-from django.conf import settings
 from django.utils.html import strip_tags
 from django.utils.safestring import mark_safe
 from django.utils.text import Truncator
@@ -43,30 +42,17 @@ def meta_description(html, max_chars=META_DESCRIPTION_MAX_CHARS):
     return Truncator(text).chars(max_chars)
 
 
-def site_scheme(request):
-    """
-    The canonical scheme for absolute URLs (https on the test/prod servers,
-    ``request.scheme`` in local dev). Single source of truth — the ``site_scheme``
-    context processor delegates here, so view-built JSON-LD URLs and template-built
-    canonical/OG URLs always agree.
-
-    We key off ``DJANGO_ENV``, NOT ``DEBUG``: the **test** server runs with
-    ``DEBUG=True`` (config-test.ini) yet sits behind the same TLS-terminating Apache
-    proxy as prod, so a DEBUG-based check emits ``http://`` on test — the exact #1236
-    bug. ``DJANGO_ENV`` is ``'TEST'``/``'PROD'`` on the servers (set by
-    rebuildanddeploy.sh) and ``'DEBUG'``/unset locally, which is the signal we want.
-
-    NOTE: in-repo workaround. #1329 (IT enabling SECURE_PROXY_SSL_HEADER) would make
-    request.scheme correct everywhere and let this fall back to it.
-    """
-    return 'https' if settings.DJANGO_ENV in ('PROD', 'TEST') else request.scheme
-
-
 def absolute_url(request, path):
-    """Build an absolute, scheme-correct URL from a root-relative path."""
+    """Build an absolute, scheme-correct URL from a root-relative path.
+
+    Uses ``request.scheme``, which is correct in every environment now that
+    ``SECURE_PROXY_SSL_HEADER`` trusts the proxy's ``X-Forwarded-Proto`` header
+    behind UW CSE's TLS-terminating Apache (#1329) — https on test/prod, http in
+    local dev. This replaced the old ``site_scheme`` DJANGO_ENV workaround (#1236).
+    """
     if not path:
         return None
-    return f"{site_scheme(request)}://{request.get_host()}{path}"
+    return f"{request.scheme}://{request.get_host()}{path}"
 
 
 def render_jsonld(data):


### PR DESCRIPTION
Final piece of #1329. Builds on #1336 (enabled `SECURE_PROXY_SSL_HEADER` on TEST/PROD) and #1338 (which verified end-to-end on `-test` that `/sitemap.xml` emits `https` from raw `request.scheme`). **Closes #1329.**

## What

Now that Django sees the real `https` scheme behind UW CSE's TLS proxy, the in-app `site_scheme` workaround from #1236 is redundant. This removes it and relies on the framework:

- **Delete** the `site_scheme` context processor (and its `TEMPLATES` registration in `settings.py`) and the `site_scheme` helper in `website/utils/metadata.py`.
- `absolute_url()` — used by views for JSON-LD `url`/`image`/`logo` — now builds from `request.scheme`.
- **Templates** (`base.html`, `member.html`, `news_item.html`, `project.html`) build canonical / OG / Twitter image URLs from `{{ request.scheme }}` instead of `{{ site_scheme }}`.

Net `-77/+63` lines; one fewer context processor running on every request.

## Tests

Reworked the scheme assertions in `test_page_metadata.py` to exercise the **real mechanism** rather than the deleted DJANGO_ENV branch:
- `test_forwarded_proto_header_drives_https` — an `X-Forwarded-Proto: https` request under `@override_settings(SECURE_PROXY_SSL_HEADER=...)` emits `https` absolute URLs (the deployed path; also sends a clean `Host` header as Apache does).
- `test_secure_request_uses_https` — a `secure=True` request emits `https`.
- `test_local_dev_uses_request_scheme` — a plain http request reflects the request scheme (`http`).
- `PageMetadataHttpsTests` now issues `secure=True` requests instead of forcing `DJANGO_ENV='PROD'`.

Full suite green in-container: **344 tests, OK (skipped=1)** (`--settings=makeabilitylab.settings_test`).

## Verification after merge → `-test`

Behavior should be unchanged (URLs were already `https` via the workaround). Confirm canonical / `og:url` / `og:image` still render `https://` on a few page types (home, a project, a member, a news item). The win is that this is now driven by the framework, not a hardcoded override.

## Note on prod

Prod still rides on `SECURE_PROXY_SSL_HEADER` (already verified on `-test`); it only takes effect in prod when you cut the next SemVer tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)