### PR TITLE
Awards page polish: clean anchors, paper counts, name spacing; retire import_awards

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -125,11 +125,6 @@ echo "4.8 Running 'python manage.py recompute_url_names' to de-collide historica
 echo "******************************************"
 python manage.py recompute_url_names
 
-echo "****************** STEP 4.9/5: docker-entrypoint.sh ************************"
-echo "4.9 Running 'python manage.py import_awards' to backfill missing Awards (idempotent)"
-echo "******************************************"
-python manage.py import_awards
-
 # echo "****************** STEP 4.3/5: docker-entrypoint.sh ************************"
 # echo "4.3 Running 'python manage.py rename_person_images' to rename person images"
 # echo "******************************************"

--- a/makeabilitylab/settings.py
+++ b/makeabilitylab/settings.py
@@ -86,8 +86,8 @@ if DJANGO_ENV in ('PROD', 'TEST'):
     SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 # Makeability Lab Global Variables, including Makeability Lab version
-ML_WEBSITE_VERSION = "2.14.0" # Keep this updated with each release and also change the short description below
-ML_WEBSITE_VERSION_DESCRIPTION = "Feature: redesigned Awards page. Each award now renders as a card with a category-specific visual anchor — recipient photo (student awards), project thumbnail (project awards), or a gold medal icon (faculty honors), with an optional uploaded emblem (new Award.badge field) overriding any of these — led by a prominent golden-orange year badge. A new idempotent import_awards management command (wired into docker-entrypoint.sh) backfills ~27 people/project/faculty awards mined from the news archive + CV that were missing from the Awards page, and corrects the mis-dated Facilitators' Choice (PrototypAR) entry. Paper awards stay on Publication.award; the one gap ('Playing on Hard Mode') is tracked in #1354. /awards/ added to the Pa11y scan set."
+ML_WEBSITE_VERSION = "2.14.1" # Keep this updated with each release and also change the short description below
+ML_WEBSITE_VERSION_DESCRIPTION = "Patch: Awards page polish. Section headings now use clean, shareable anchor IDs (e.g. #student-awards, #best-paper-awards instead of #section-...-heading); recipient/project lists no longer render a stray space before the comma ('Name, Project'); and the Best/Other Paper Award headings show a count, e.g. 'Best Paper Awards (12)'. Also retires the one-time import_awards step from the deploy sequence now that the backfill has run on test + prod — the management command stays in the repo (unwired, re-runnable) so a future rebuild can replay it."
 DATE_MAKEABILITYLAB_FORMED = datetime.date(2012, 1, 1)  # Date Makeability Lab was formed
 MAX_BANNERS = 7 # Maximum number of banners on a page
 

--- a/website/templates/snippets/display_award_snippet.html
+++ b/website/templates/snippets/display_award_snippet.html
@@ -54,13 +54,11 @@ markup stays free of inline styles.
 
     {% if award.organization %}<p class="award-org">{{ award.organization }}</p>{% endif %}
 
+    {# Recipients, then publicly-visible projects (private ones omitted, #1300). The
+       endfor/connector/for junctions are kept whitespace-tight on one line so the
+       output reads "Name, Project" and never "Name , Project". #}
     <p class="award-recipients">
-      {% for person in award.recipients.all %}<a href="{% url 'website:member_by_name' person.get_url_name %}">{{ person.get_full_name }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}
-
-      {% if award.recipients.exists and award.get_visible_projects.exists %}, {% endif %}
-
-      {# Only list publicly-visible projects so private projects aren't named here (#1300) #}
-      {% for project in award.get_visible_projects %}<a href="{% url 'website:project' project.short_name %}">{{ project.name }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}
+      {% for person in award.recipients.all %}<a href="{% url 'website:member_by_name' person.get_url_name %}">{{ person.get_full_name }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}{% if award.recipients.exists and award.get_visible_projects.exists %}, {% endif %}{% for project in award.get_visible_projects %}<a href="{% url 'website:project' project.short_name %}">{{ project.name }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}
     </p>
 
     {% if award.description %}

--- a/website/templates/website/awards.html
+++ b/website/templates/website/awards.html
@@ -51,10 +51,10 @@ document.addEventListener('DOMContentLoaded', function() {
 
         <!-- ===== People & project distinctions, sectioned by award_type ===== -->
         {% for section in distinction_sections %}
-        <section aria-labelledby="section-{{ section.label|slugify }}-heading">
-          <h2 id="section-{{ section.label|slugify }}-heading" class="heading-with-anchor">
+        <section aria-labelledby="{{ section.label|slugify }}">
+          <h2 id="{{ section.label|slugify }}" class="heading-with-anchor">
             {{ section.label }}
-            <a href="#section-{{ section.label|slugify }}-heading" class="header-anchor"
+            <a href="#{{ section.label|slugify }}" class="header-anchor"
                aria-label="Link to {{ section.label }} section">
               <i class="fa-solid fa-link" aria-hidden="true"></i>
             </a>
@@ -71,10 +71,10 @@ document.addEventListener('DOMContentLoaded', function() {
         {% endfor %}
 
         <!-- ===== Best Paper Awards ===== -->
-        <section aria-labelledby="best-paper-awards-heading">
-          <h2 id="best-paper-awards-heading" class="heading-with-anchor">
-            Best Paper Awards
-            <a href="#best-paper-awards-heading" class="header-anchor"
+        <section aria-labelledby="best-paper-awards">
+          <h2 id="best-paper-awards" class="heading-with-anchor">
+            Best Paper Awards ({{ best_paper_pubs|length }})
+            <a href="#best-paper-awards" class="header-anchor"
                aria-label="Link to Best Paper Awards section">
               <i class="fa-solid fa-link" aria-hidden="true"></i>
             </a>
@@ -90,10 +90,10 @@ document.addEventListener('DOMContentLoaded', function() {
         </section>
 
         <!-- ===== Other Paper Awards ===== -->
-        <section aria-labelledby="other-paper-awards-heading">
-          <h2 id="other-paper-awards-heading" class="heading-with-anchor">
-            Other Paper Awards
-            <a href="#other-paper-awards-heading" class="header-anchor"
+        <section aria-labelledby="other-paper-awards">
+          <h2 id="other-paper-awards" class="heading-with-anchor">
+            Other Paper Awards ({{ other_award_pubs|length }})
+            <a href="#other-paper-awards" class="header-anchor"
                aria-label="Link to Other Paper Awards section">
               <i class="fa-solid fa-link" aria-hidden="true"></i>
             </a>

--- a/website/tests/test_award.py
+++ b/website/tests/test_award.py
@@ -11,6 +11,7 @@ real queryset (M2M relations, project visibility), so it belongs here rather
 than in a SimpleTestCase.
 """
 
+import re
 from datetime import date
 
 from django.urls import reverse
@@ -115,3 +116,35 @@ class AwardsPageRenderTests(DatabaseTestCase):
         self.assertIn("award-card", html)
         self.assertIn("award-card--medal", html)  # faculty honor -> medal anchor
         self.assertIn("2017", html)                # prominent year is rendered
+
+    def test_recipient_and_project_join_has_no_stray_space(self):
+        # Regression: the recipient/project connector rendered as "Name , Project"
+        # due to template whitespace between the two loops.
+        person = self.make_person(first_name="Chu", last_name="Li")
+        project = self.make_project(name="AltGeoViz", short_name="altgeoviz", is_visible=True)
+        award = Award.objects.create(title="People's Choice Award", date=date(2024, 10, 29),
+                                     award_type=AwardType.PROJECT_AWARD)
+        award.recipients.set([person])
+        award.projects.set([project])
+
+        html = self.client.get(reverse("website:awards")).content.decode()
+        # Strip tags (names sit inside <a>…</a>), then collapse whitespace, so we
+        # compare the *visible* text the way a reader sees it.
+        text = re.sub(r"\s+", " ", re.sub(r"<[^>]+>", "", html))
+        self.assertIn("Chu Li, AltGeoViz", text)
+        self.assertNotIn("Chu Li , AltGeoViz", text)
+
+    def test_section_anchors_are_clean_and_paper_sections_show_counts(self):
+        self.make_publication(title="A Great Paper", year=2020, award="Best Paper Award")
+        Award.objects.create(title="A Faculty Honor", date=date(2017, 5, 1),
+                             award_type=AwardType.FACULTY_HONOR).recipients.set([self.make_person()])
+
+        html = self.client.get(reverse("website:awards")).content.decode()
+        # Clean, shareable anchor IDs (no verbose 'section-...-heading').
+        self.assertIn('id="faculty-honors"', html)
+        self.assertIn('id="best-paper-awards"', html)
+        self.assertNotIn("section-faculty-honors-heading", html)
+        self.assertNotIn("best-paper-awards-heading", html)
+        # Paper-section counts.
+        self.assertIn("Best Paper Awards (1)", html)
+        self.assertIn("Other Paper Awards (0)", html)


### PR DESCRIPTION
Follow-up to #1355 (Awards redesign), addressing review feedback after it shipped to prod in 2.14.0.

## Changes
1. **Clean, shareable section anchors** — headings now use `#student-awards`, `#faculty-honors`, `#project-awards`, `#best-paper-awards`, `#other-paper-awards` instead of the verbose `#section-…-heading`. Nicer for sharing direct links.
2. **Counts on the paper sections** — "Best Paper Awards (N)" / "Other Paper Awards (N)".
3. **Stray-space fix** — recipient/project lists rendered as "Chu Li , AltGeoViz" (template whitespace between the two loops); now "Chu Li, AltGeoViz".
4. **Retire `import_awards` from the deploy** — the one-time backfill has run on test + prod, so it's removed from `docker-entrypoint.sh`. It no longer re-runs every deploy (which would resurrect any award you delete in the admin). The command + tests stay in the repo, unwired and re-runnable.

## Deploy notes
No schema change. Removing the entrypoint step just means the importer stops running on container start; existing award rows are untouched.

## Tests
`website/tests/test_award.py` — added regression tests for the name spacing and the clean-anchor/count markup. Full award + import suites pass locally (`--settings=makeabilitylab.settings_test`).

## Version
Bumps to **2.14.1** (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)