### PR TITLE
Hotfix: award snippet leaked a multi-line {# #} comment onto every card (2.14.2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,12 @@ News items use `django-ckeditor`. Uploaded files via CKEditor land under `media/
 - Document to language convention: JSDoc for JS, docstrings for Python views/
   models/management commands. Add usage examples for non-obvious logic.
 - HTML/Django templates: 2-space indentation; djlint is the formatter.
+- **Django template comments — `{# … #}` is SINGLE-LINE ONLY.** A `{# … #}` that
+  spans multiple lines is NOT parsed as a comment; Django renders the whole thing
+  (text and `#}` included) as visible page content. For any multi-line comment use
+  `{% comment %} … {% endcomment %}`. This is a recurring footgun (it shipped to
+  prod once as a comment printed on every award card, fixed in 2.14.2) — when
+  adding or editing a `{# … #}`, confirm it stays on one line.
 - Prefer clarity over cleverness; mark placeholders and TODOs clearly.
 
 ## Pull request conventions (from CONTRIBUTING.md)

--- a/makeabilitylab/settings.py
+++ b/makeabilitylab/settings.py
@@ -86,8 +86,8 @@ if DJANGO_ENV in ('PROD', 'TEST'):
     SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 # Makeability Lab Global Variables, including Makeability Lab version
-ML_WEBSITE_VERSION = "2.14.1" # Keep this updated with each release and also change the short description below
-ML_WEBSITE_VERSION_DESCRIPTION = "Patch: Awards page polish. Section headings now use clean, shareable anchor IDs (e.g. #student-awards, #best-paper-awards instead of #section-...-heading); recipient/project lists no longer render a stray space before the comma ('Name, Project'); and the Best/Other Paper Award headings show a count, e.g. 'Best Paper Awards (12)'. Also retires the one-time import_awards step from the deploy sequence now that the backfill has run on test + prod — the management command stays in the repo (unwired, re-runnable) so a future rebuild can replay it."
+ML_WEBSITE_VERSION = "2.14.2" # Keep this updated with each release and also change the short description below
+ML_WEBSITE_VERSION_DESCRIPTION = "Hotfix: a multi-line {# #} explanatory comment added to the award snippet in 2.14.1 rendered as literal text on every award card (Django's {# #} only supports single-line comments). Replaced it with a {% comment %} block so it no longer leaks into the page; added a regression test guarding against leaked template comments."
 DATE_MAKEABILITYLAB_FORMED = datetime.date(2012, 1, 1)  # Date Makeability Lab was formed
 MAX_BANNERS = 7 # Maximum number of banners on a page
 

--- a/website/templates/snippets/display_award_snippet.html
+++ b/website/templates/snippets/display_award_snippet.html
@@ -54,9 +54,12 @@ markup stays free of inline styles.
 
     {% if award.organization %}<p class="award-org">{{ award.organization }}</p>{% endif %}
 
-    {# Recipients, then publicly-visible projects (private ones omitted, #1300). The
-       endfor/connector/for junctions are kept whitespace-tight on one line so the
-       output reads "Name, Project" and never "Name , Project". #}
+    {% comment %}
+    Recipients, then publicly-visible projects (private ones omitted, #1300). The
+    endfor/connector/for junctions below are kept whitespace-tight on one line so
+    the output reads "Name, Project" and never "Name , Project". (Django's {# #}
+    only supports single-line comments, so this multi-line note uses a block tag.)
+    {% endcomment %}
     <p class="award-recipients">
       {% for person in award.recipients.all %}<a href="{% url 'website:member_by_name' person.get_url_name %}">{{ person.get_full_name }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}{% if award.recipients.exists and award.get_visible_projects.exists %}, {% endif %}{% for project in award.get_visible_projects %}<a href="{% url 'website:project' project.short_name %}">{{ project.name }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}
     </p>

--- a/website/tests/test_award.py
+++ b/website/tests/test_award.py
@@ -133,6 +133,10 @@ class AwardsPageRenderTests(DatabaseTestCase):
         text = re.sub(r"\s+", " ", re.sub(r"<[^>]+>", "", html))
         self.assertIn("Chu Li, AltGeoViz", text)
         self.assertNotIn("Chu Li , AltGeoViz", text)
+        # A multi-line {# #} renders as literal text in Django (the 2.14.1 -> 2.14.2
+        # hotfix). Guard against any leaked template comment.
+        self.assertNotIn("{#", html)
+        self.assertNotIn("whitespace-tight", html)
 
     def test_section_anchors_are_clean_and_paper_sections_show_counts(self):
         self.make_publication(title="A Great Paper", year=2020, award="Best Paper Award")


### PR DESCRIPTION
## Problem (live on prod)
The explanatory comment I added to `display_award_snippet.html` in 2.14.1 (#1356) was a **multi-line `{# #}`** comment. Django's `{# #}` only supports **single-line** comments, so the whole thing — including the literal text *'…output reads "Name, Project" and never "Name , Project". #}'* — rendered as visible text on **every award card** on production.

(The actual recipient/project spacing fix from 2.14.1 is fine; this was a separate, self-inflicted regression in the *comment*.)

## Fix
Replace the multi-line `{# #}` with a `{% comment %}…{% endcomment %}` block (multi-line safe, renders nothing).

## Test
Added guards to the award render test: the page must not contain `{#` or the explanatory text. The existing spacing test missed this because the leaked comment used placeholder names ("Name") rather than the test's data. All 12 award tests pass.

## Version
**2.14.2** (hotfix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)