### PR TITLE
chore(release): 2.16.1 — shorten home <title> to 'HCI & AI Research at UW'

### DIFF
--- a/makeabilitylab/settings.py
+++ b/makeabilitylab/settings.py
@@ -86,8 +86,8 @@ if DJANGO_ENV in ('PROD', 'TEST'):
     SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 # Makeability Lab Global Variables, including Makeability Lab version
-ML_WEBSITE_VERSION = "2.16.0" # Keep this updated with each release and also change the short description below
-ML_WEBSITE_VERSION_DESCRIPTION = "Keyword taxonomy cleanup tooling (#1352): a 'Merge selected keywords' admin action on the Keyword changelist that reassigns every reference (across Publications, Talks, Posters, Grants, Projects, and Project Umbrellas) onto a chosen target and deletes the duplicates, plus a read-only 'Duplicate keywords' Data Health check that finds case/whitespace variants and deep-links to the filtered changelist to merge them. Keyword.save() now normalizes whitespace so casual variants can't be created. Also: the merge reassigns at the M2M through-table level to stay compatible with the legacy sort_value column on website_publication_keywords. Admin hygiene (#1346): the Photo changelist no longer crashes on a missing image file and now shows the owning project. SEO on-page fixes (duplicate <title>, /None sponsor links, YouTube embed)."
+ML_WEBSITE_VERSION = "2.16.1" # Keep this updated with each release and also change the short description below
+ML_WEBSITE_VERSION_DESCRIPTION = "SEO: shorten the home page <title> to 'HCI & AI Research at UW | Makeability Lab' so it stays under Google's ~60-character display limit (the 2.16.0 'University of Washington' variant was truncated). Follow-up to the 2.16.0 on-page SEO fixes."
 DATE_MAKEABILITYLAB_FORMED = datetime.date(2012, 1, 1)  # Date Makeability Lab was formed
 MAX_BANNERS = 7 # Maximum number of banners on a page
 

--- a/website/templates/website/index.html
+++ b/website/templates/website/index.html
@@ -51,7 +51,7 @@ CONTEXT VARIABLES:
 {% endcomment %}
 
 {# base.html appends " | Makeability Lab", so this block holds only the descriptive prefix (repeating the lab name here caused a duplicated title). #}
-{% block pagetitle %}HCI &amp; AI Research at the University of Washington{% endblock %}
+{% block pagetitle %}HCI &amp; AI Research at UW{% endblock %}
 
 {% load static %}
 {% load thumbnail %}

--- a/website/tests/test_page_metadata.py
+++ b/website/tests/test_page_metadata.py
@@ -76,9 +76,7 @@ class PageMetadataHttpsTests(DatabaseTestCase):
         resp = self.client.get(reverse("website:index"), secure=True)
         self.assertNotContains(resp, "<title>Makeability Lab | Makeability Lab</title>")
         self.assertContains(
-            resp,
-            "<title>HCI &amp; AI Research at the University of Washington "
-            "| Makeability Lab</title>",
+            resp, "<title>HCI &amp; AI Research at UW | Makeability Lab</title>"
         )
 
     def test_no_http_scheme_in_social_urls(self):


### PR DESCRIPTION
## Summary

Cuts **2.16.1**, a follow-up to the on-page SEO fixes that shipped in 2.16.0.

The home `<title>` shipped in 2.16.0 as:

> `HCI & AI Research at the University of Washington | Makeability Lab` (~66 chars)

Google truncates titles around ~60 characters, so the lab name (our brand) risked being cut off in search results. This shortens the descriptive prefix to **"at UW"**:

> `HCI & AI Research at UW | Makeability Lab` (~41 chars)

## Why this wording

- Keeps the high-recall **"HCI & AI"** keywords — the canonical terms people search for an HCI/accessibility research lab (higher search volume than "Human-AI").
- Stays well under the truncation limit, so `| Makeability Lab` always shows.
- We don't lose the UW association: **"University of Washington"** still appears in the page's `Organization` JSON-LD (`parentOrganization`) and in the About body copy.

## Changes

- `website/templates/website/index.html` — title block prefix → `HCI &amp; AI Research at UW`.
- `website/tests/test_page_metadata.py` — `test_home_title_is_not_duplicated` updated to assert the new title.
- `makeabilitylab/settings.py` — bump `ML_WEBSITE_VERSION` to `2.16.1` + description.

## Before / after (home `<title>`)

| | Title |
|---|---|
| Before (2.16.0) | `HCI & AI Research at the University of Washington \| Makeability Lab` |
| After (2.16.1)  | `HCI & AI Research at UW \| Makeability Lab` |

This is a `<title>`-only content change (no visible page layout change), so no UI screenshots apply.

## Testing

`python manage.py test website.tests.test_page_metadata --settings=makeabilitylab.settings_test` — passes.

## Deploy

Merging to `master` auto-deploys to test. Tag `2.16.1` to ship to prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)