### PR TITLE
fix(analytics): migrate to native GA4 gtag.js, drop dead UA tag (#855)

### DIFF
--- a/makeabilitylab/settings.py
+++ b/makeabilitylab/settings.py
@@ -86,8 +86,8 @@ if DJANGO_ENV in ('PROD', 'TEST'):
     SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 # Makeability Lab Global Variables, including Makeability Lab version
-ML_WEBSITE_VERSION = "2.16.1" # Keep this updated with each release and also change the short description below
-ML_WEBSITE_VERSION_DESCRIPTION = "SEO: shorten the home page <title> to 'HCI & AI Research at UW | Makeability Lab' so it stays under Google's ~60-character display limit (the 2.16.0 'University of Washington' variant was truncated). Follow-up to the 2.16.0 on-page SEO fixes."
+ML_WEBSITE_VERSION = "2.16.2" # Keep this updated with each release and also change the short description below
+ML_WEBSITE_VERSION_DESCRIPTION = "Analytics: load Google Analytics 4 (G-M18PCH55ZP) directly via the native gtag.js snippet instead of chain-loading it off the retired Universal Analytics analytics.js tag (a console-side 'connected site tag'). Removes the dead UA-79723676-1 snippet so GA4 collection no longer depends on deprecated UA machinery (#855)."
 DATE_MAKEABILITYLAB_FORMED = datetime.date(2012, 1, 1)  # Date Makeability Lab was formed
 MAX_BANNERS = 7 # Maximum number of banners on a page
 

--- a/website/templates/website/base.html
+++ b/website/templates/website/base.html
@@ -152,13 +152,15 @@ TEMPLATE BLOCKS:
   {% if debug %}
   <script>console.log("Development mode: Google Analytics disabled");</script>
   {% else %}
+  <!-- Google tag (gtag.js) — GA4 property G-M18PCH55ZP (#855).
+       Loads GA4 directly instead of chain-loading it off the retired Universal
+       Analytics analytics.js tag via a console-side "connected site tag". -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-M18PCH55ZP"></script>
   <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-    ga('create', 'UA-79723676-1', 'auto');
-    ga('send', 'pageview');
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-M18PCH55ZP');
   </script>
   {% endif %}
 </head>


### PR DESCRIPTION
## Summary

Production was firing native GA4 (`G-M18PCH55ZP`) only **indirectly**. The inline Universal Analytics snippet loaded `analytics.js`, which chain-loaded the GA4 `gtag` via a console-side **"connected site tag"** (visible in DevTools as `gtag/js?id=G-M18PCH55ZP&…&_slc=1`, initiated from `analytics.js`):

```
makeabilitylab.cs.washington.edu/        ← inline UA snippet
  └─ google-analytics.com/analytics.js    ← retired UA library
      └─ googletagmanager.com/gtag/js?id=G-M18PCH55ZP&…&_slc=1   ← chained GA4
          └─ google-analytics.com/g/collect?v=2&tid=G-M18PCH55ZP&…en=page_view
```

That bridge rides on the **retired UA library** plus a linkage that lives **only in the GA admin console**, not in the repo — so GA4 would silently stop collecting if the legacy machinery is removed (or if someone deletes the obviously-dead UA snippet). This is the code side of #855, which originally "shipped GA4" purely via the console with no code change.

## Change

- `website/templates/website/base.html` — replace the UA `analytics.js` / `UA-79723676-1` snippet with the **official native `gtag.js`** snippet for `G-M18PCH55ZP`. GA4 now loads directly, version-controlled, with no dependency on the deprecated UA path. Keeps the `{% if debug %}` gate (prod-only).
- `makeabilitylab/settings.py` — bump `2.16.1` → `2.16.2`.

No double-counting: removing the UA snippet kills the chain trigger, so only the direct gtag fires.

## Verification

- Not visible on `-test`/local (GA4 is gated off when `DEBUG=True` — expected).
- After prod deploy (SemVer tag): DevTools → Network → filter `G-M18PCH55ZP` → the `gtag/js` request's **Initiator** should be `(index)` directly, **not** `analytics.js`. GA4 Realtime should still show traffic.

## Follow-up (not in this PR)

- Once confirmed on prod, optionally delete the now-inert "connected site tag" in the GA console and retire the old UA property (tidiness only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)