### PR TITLE
fix(version): populate /version/ git_sha and built_at in deployed envs (#1366)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ RUN pip install --upgrade pip
 # - imagemagick: Image processing for thumbnails and conversions
 # - ghostscript: PDF processing (required by imagemagick for PDFs)
 # - sqlite3: Useful for debugging, though we use PostgreSQL in production
+# - git: lets docker-entrypoint.sh capture the deployed commit SHA into
+#        build-info.json for the /version/ endpoint (#1366)
 #
 # We clean up the apt cache afterward to reduce the final image size.
 RUN apt-get update \
@@ -33,6 +35,7 @@ RUN apt-get update \
         imagemagick \
         ghostscript \
         sqlite3 \
+        git \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -52,10 +52,15 @@ echo ""
 # capture the short SHA + a timestamp ONCE here (not per request) into a small
 # build-info.json that website/views/version.py reads. Falls back to "unknown"
 # if git isn't available (the view also tolerates a missing file).
+#
+# On the servers /code is a bind-mount whose .git is owned by apache:makelab
+# while this script runs as root, so git's "dubious ownership" guard would
+# otherwise refuse to run -- mark /code safe first (-c is process-local, no
+# global config side effects). git is installed in the Dockerfile.
 echo "****************** STEP -1/5: docker-entrypoint.sh ************************"
 echo "-1. Writing build-info.json (git sha + build timestamp) for /version/"
 echo "******************************************"
-GIT_SHA=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+GIT_SHA=$(git -c safe.directory=/code -C /code rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILT_AT=$(date --iso-8601=seconds 2>/dev/null || echo "unknown")
 printf '{"git_sha": "%s", "built_at": "%s"}\n' "$GIT_SHA" "$BUILT_AT" > build-info.json
 cat build-info.json

--- a/makeabilitylab/settings.py
+++ b/makeabilitylab/settings.py
@@ -86,8 +86,8 @@ if DJANGO_ENV in ('PROD', 'TEST'):
     SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 # Makeability Lab Global Variables, including Makeability Lab version
-ML_WEBSITE_VERSION = "2.17.1" # Keep this updated with each release and also change the short description below
-ML_WEBSITE_VERSION_DESCRIPTION = "Add an admin Data Health check, 'Artifacts not linked to a project' (/admin/data-health/), that surfaces every talk, paper, video, and poster with no project assigned so the backlog stays visible and shrinks over time. Pre-Makeability-Lab work (before settings.DATE_MAKEABILITYLAB_FORMED) is excluded, rows whose parent publication is already linked are flagged as quick wins (inherit its projects), and each row deep-links to its admin edit page. Read-only with CSV export. Also keeps data-health row-action buttons from wrapping mid-word in narrow columns (#649)."
+ML_WEBSITE_VERSION = "2.17.2" # Keep this updated with each release and also change the short description below
+ML_WEBSITE_VERSION_DESCRIPTION = "Fix the /version/ endpoint reporting git_sha and built_at as 'unknown' in deployed environments. The build-info capture in docker-entrypoint.sh needs git (it wasn't installed in the image) and trips git's 'dubious ownership' guard because /code/.git is apache:makelab-owned while the container runs as root. Installs git in the Dockerfile and runs rev-parse with -c safe.directory=/code. The Dockerfile change also forces an image rebuild on deploy, so the entrypoint actually re-runs and writes build-info.json (#1366)."
 DATE_MAKEABILITYLAB_FORMED = datetime.date(2012, 1, 1)  # Date Makeability Lab was formed
 MAX_BANNERS = 7 # Maximum number of banners on a page
 


### PR DESCRIPTION
Follow-up to #1366. On the deployed servers, `/version/` reported `"git_sha": "unknown"` and `"built_at": "unknown"`.

## Root causes
1. **`git` was never installed in the image.** `docker-entrypoint.sh` runs `git rev-parse` to capture the deployed SHA, but the Dockerfile only installed imagemagick / ghostscript / sqlite3 — so the command always failed → `git_sha: "unknown"`.
2. **git's "dubious ownership" guard.** On the servers `/code/.git` is `apache:makelab`-owned while the container runs as root; even with git installed, `git rev-parse` would refuse with *"detected dubious ownership in repository"*.
3. **`built_at` was *also* unknown** because the build-info step only runs at container start, and the live prod container predates #1366 — code updates reach it via the bind-mount + autoreload, but the entrypoint never re-ran, so `build-info.json` was never written.

## Fix
- Install `git` in the Dockerfile.
- Run `git -c safe.directory=/code -C /code rev-parse --short HEAD` in the entrypoint (`-c` is process-local — no global git config side effects).
- The Dockerfile change forces an image rebuild on the next deploy → `docker compose up -d` recreates the container → the entrypoint re-runs and writes `build-info.json`.

## Verification (local)
Ran the exact entrypoint commands in the container:
```
{"git_sha": "09d6f2f", "built_at": "2026-06-22T15:14:10+00:00"}
```
and `/version.json` then reported both. `build-info.json` remains gitignored.

Bumps version to **2.17.2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)