### PR TITLE
fix(admin): label mentor field "Mentor" not "Grad mentor" (#806)

### DIFF
--- a/website/models/position.py
+++ b/website/models/position.py
@@ -57,7 +57,13 @@ class Position(models.Model):
     end_date = models.DateField(blank=True, null=True)
     advisor = models.ForeignKey('Person', blank=True, null=True, related_name='Advisor', on_delete=models.SET_NULL)
     co_advisor = models.ForeignKey('Person', blank=True, null=True, related_name='Co_Advisor', verbose_name='Co-advisor', on_delete=models.SET_NULL)
-    grad_mentor = models.ForeignKey('Person', blank=True, null=True, related_name='Grad_Mentor', on_delete=models.SET_NULL)
+    # Field is named ``grad_mentor`` for historical reasons, but the dropdown allows any active
+    # senior lab member (not just grad students) — see get_active_mentors_queryset — so the
+    # user-facing label is simply "Mentor" (issue #806). The DB column is intentionally NOT
+    # renamed: this repo regenerates migrations non-interactively per-environment, where a field
+    # rename can't be confirmed and would drop the column. verbose_name fixes the label with no
+    # schema change.
+    grad_mentor = models.ForeignKey('Person', blank=True, null=True, related_name='Grad_Mentor', verbose_name='Mentor', on_delete=models.SET_NULL)
     role = models.CharField(max_length=50, choices=Role.choices, default=Role.MEMBER)
     title = models.CharField(max_length=50, choices=Title.choices)
 

--- a/website/tests/test_position_mentor_label.py
+++ b/website/tests/test_position_mentor_label.py
@@ -1,0 +1,19 @@
+"""
+Regression test for issue #806.
+
+The Position.grad_mentor field keeps its historical Python/DB name, but the
+mentor dropdown is no longer grad-only (see get_active_mentors_queryset), so the
+user-facing admin label was changed to simply "Mentor" via verbose_name. This
+pins that label so a future edit to the field doesn't silently revert it to the
+auto-generated "Grad mentor".
+"""
+
+from django.test import SimpleTestCase
+
+from website.models import Position
+
+
+class MentorLabelTests(SimpleTestCase):
+    def test_grad_mentor_field_labeled_mentor(self):
+        field = Position._meta.get_field("grad_mentor")
+        self.assertEqual(field.verbose_name, "Mentor")


### PR DESCRIPTION
Closes #806.

## Background
Issue #806 (2019) reported that non-grad members (e.g. a software developer like "Mikey") couldn't be selected as a "Grad Mentor", and proposed renaming the field to "Mentor" so any active member could be chosen. A co-mentor field was also floated.

## What's actually true today
- **Selectability is already fixed.** `get_active_mentors_queryset()` (`website/admin/utils.py`) populates the dropdown with any active senior lab member — PhD/MS students, postdocs, the director, software developers, designers, and research scientists — not just grad students. The original "can't select Mikey" complaint no longer applies.
- The **only** thing that still read "Grad Mentor" was the admin field label. Public bios already say "mentored by …" (`bio_utils.py`), never "grad mentor".

## This PR
Sets `verbose_name='Mentor'` on `Position.grad_mentor` so the admin label reads **"Mentor"**, matching the broadened behavior.

The DB column is **intentionally not renamed**. This repo regenerates `website/migrations/` non-interactively per environment; a field rename can't be confirmed at startup and would be applied as drop-column + add-column — i.e. data loss. That was the exact server-access blocker noted on #806 in 2019. `verbose_name` is a state-only change with no schema impact, so it's safe to push.

**Co-mentor field:** deliberately not added — no demonstrated demand.

## Test
Adds `test_position_mentor_label.py` pinning `verbose_name == "Mentor"` so the label can't silently regress. Passing locally.
