### PR TITLE
Fix stale People-page description test assertion

### DIFF
--- a/website/tests/test_page_metadata.py
+++ b/website/tests/test_page_metadata.py
@@ -155,7 +155,7 @@ class ListPageDescriptionTests(DatabaseTestCase):
 
     def test_people_description(self):
         self._assert_distinct("website:people", "People",
-                              "Meet the faculty, students, postdocs, and alumni")
+                              "Meet the faculty, students, and alumni")
 
     def test_projects_description(self):
         self._assert_distinct("website:projects", "Projects",


### PR DESCRIPTION
Small follow-up: commit 7e497aa ("Changed language for page_meta since we have never had a postdoc") updated the People page meta description to drop "postdocs", but `test_people_description` still asserted the old `"...students, postdocs, and alumni"` string — so the test suite was red on `master`.

This aligns the assertion with the current copy in `website/views/people.py` (`"Meet the faculty, students, and alumni …"`).

No production behavior change; test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)