### PR TITLE
Add edit-action link to the media-integrity data-health check

### DIFF
--- a/website/admin/data_health/checks/media_integrity.py
+++ b/website/admin/data_health/checks/media_integrity.py
@@ -16,6 +16,7 @@ import glob
 import os
 
 from django.conf import settings
+from django.urls import reverse
 
 from website.admin.data_health.registry import HealthCheck, register_check
 from website.models import Poster, Publication, Talk
@@ -52,6 +53,20 @@ class MediaIntegrityCheck(HealthCheck):
             rows.extend(self._missing_files(model))
             rows.extend(self._orphan_files(model))
         return rows
+
+    def row_link(self, row):
+        """Deep-link a ``missing-file`` row to its artifact's admin edit page so
+        the editor can re-upload the file or clear the dead reference right
+        there (mirrors the action buttons on the other checks).
+
+        ``orphan-file`` rows have no DB object to open — they're files on disk
+        that ``delete_unused_files`` would remove — so they get no link.
+        """
+        if row.get('status') != 'missing-file' or not row.get('id'):
+            return None
+        url = reverse(f"admin:website_{row['type'].lower()}_change",
+                      args=[row['id']])
+        return ('Open →', url)
 
     def _missing_files(self, model):
         """DB rows whose file field is set but the file is gone from disk."""

--- a/website/tests/test_data_health.py
+++ b/website/tests/test_data_health.py
@@ -303,6 +303,33 @@ class MediaIntegrityCheckTests(DatabaseTestCase):
         ]
         self.assertTrue(hits)
 
+    def test_missing_file_row_links_to_admin_edit(self):
+        """A missing-file row gets an 'Open →' action to the artifact's admin
+        edit page; orphan-file rows (no DB object) get no link."""
+        pub = self.make_publication(title="Vanishing Paper")
+        path = pub.pdf_file.path
+        if os.path.exists(path):
+            os.remove(path)
+
+        check = get_check("media-integrity")
+        missing = next(
+            r
+            for r in check.get_rows()
+            if r["type"] == "Publication"
+            and r["id"] == pub.pk
+            and r["status"] == "missing-file"
+        )
+        label, url = check.row_link(missing)
+        self.assertEqual(label, "Open →")
+        self.assertEqual(
+            url, reverse("admin:website_publication_change", args=[pub.pk])
+        )
+
+        # Orphan-file rows carry no id and must not produce a link.
+        self.assertIsNone(
+            check.row_link({"type": "Publication", "id": "", "status": "orphan-file"})
+        )
+
 
 class DataHealthReadOnlyTests(DatabaseTestCase):
     def test_get_rows_does_not_mutate_db(self):


### PR DESCRIPTION
## What
The **Media / file integrity** Data Health check surfaces artifacts whose `pdf_file` / `raw_file` / `thumbnail` reference points at a file missing on disk — but, unlike the other checks (e.g. `unlinked-artifacts`), it offered no way to act on a row.

This adds a `row_link` so each **missing-file** row gets an **"Open →"** button linking to that artifact's admin edit page, where the editor can re-upload the file or clear the dead reference. Orphan-file rows (a file on disk with no DB row — handled by `delete_unused_files`) have no object to open, so they intentionally get no link.

## Why
Came out of #840: a missing artifact file 500'd the publications listing (fixed separately in #1374). This check is the right place to *find and fix* those missing files on -test/prod, and an action button makes it one click instead of a manual hunt.

No new dependency or template change — the dashboard's existing `row_link` plumbing (`views.py` + `detail.html`) already renders an "Action" column when a check provides links.

## Tests
`test_missing_file_row_links_to_admin_edit` in `website/tests/test_data_health.py` — asserts the "Open →" link targets the admin change page and that orphan-file rows get no link. Full `test_data_health` suite green (23 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)