### PR TITLE
Lift revealed publication chips above neighboring cards (#1377)

### DIFF
--- a/website/static/website/css/publications.css
+++ b/website/static/website/css/publications.css
@@ -165,9 +165,20 @@
   transition: opacity var(--transition-fast);
 }
 
+/* On hover/focus, reveal the chips AND lift them onto a higher stacking
+   layer so they paint on top of whatever sits below them rather than
+   tangling behind it (#1377). The .pub-download-links row can extend past
+   the card's 129px box, and the landing grid is a flex-wrap row, so a
+   card's chips can overlap the title of the card in the row below; raising
+   z-index keeps the revealed chips legible and on top. z-index is applied
+   only on hover/focus so the invisible (opacity:0) layer never sits over —
+   and swallows clicks meant for — the card below. 30 clears the thumbnail
+   (z-index:10) and award banner (z-index:20). */
 .pub-column-horiz-layout:hover .pub-download-links,
 .pub-column-horiz-layout:focus-within .pub-download-links {
   opacity: 1;
+  position: relative;
+  z-index: 30;
 }
 
 


### PR DESCRIPTION
Fixes #1377.

## Problem
On the landing page, the horizontal publication card's `.pub-download-links` row (PDF/Cite/project chips) is hidden with `opacity:0`, which still occupies layout space. That row can extend past the card's 129px box, and the landing grid is a `flex-wrap` row, so a card's revealed-on-hover chips can sit over the title of the card in the row below (or, in the last row, over "SEE ALL PAPERS"). At the default stacking order the chips painted *behind* that content and looked tangled — the reported "sometimes the chips overlap" (the "sometimes" being the variable stack height: author count, chip count, title length).

## Fix
On `:hover`/`:focus-within`, give the revealed chips `position: relative` and `z-index: 30` so they paint cleanly **on top** of whatever is below them instead of tangling behind it.

```css
.pub-column-horiz-layout:hover .pub-download-links,
.pub-column-horiz-layout:focus-within .pub-download-links {
  opacity: 1;
  position: relative;
  z-index: 30; /* clears thumbnail (10) & award banner (20) */
}
```

- `z-index` is applied **only** on hover/focus, so the invisible (`opacity:0`) layer never sits over — and swallows clicks meant for — the card below. At-rest behavior is unchanged.
- `30` clears the existing thumbnail (`z-index:10`) and award banner (`z-index:20`) stacking.

This fixes the *layering* (chips legible, on top); it intentionally doesn't reserve extra space, so the transient on-hover overlap itself remains by design.

## Verification
- Real `:hover` on the chip-heavy "At the Intersection…" card: revealed chips now sit cleanly on top of the content below (before/after crop to be attached).
- a11y: no change to colors/contrast, DOM order, or keyboard reveal (`:focus-within` preserved). Pa11y landing-page findings are the pre-existing media-less `color-contrast` noise; none reference the touched selectors.
- No Django test applies (pure CSS render bug, not reachable via the Python suite).

## Screenshot
<img width="440" height="255" alt="image" src="https://github.com/user-attachments/assets/5bc91b7b-f4c3-43cb-93b5-4002eff5add7" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)