### PR TITLE
Run Gunicorn on test/prod instead of Django's dev runserver (#1034)

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -164,8 +164,39 @@ python manage.py setup_admin_groups
 # python manage.py rename_talk_files
 
 # Start server
-echo "Starting server"
+#
+# Production-grade environments (TEST, PROD) run Gunicorn, the recommended WSGI
+# server. Local development (DJANGO_ENV=DEBUG) keeps Django's `runserver` for
+# its auto-reload on code edits, friendlier tracebacks, debug toolbar, and
+# static-file serving under DEBUG=True. See issue #1034.
+#
+# This swap is entirely inside the container -- UW CSE's Apache still reverse-
+# proxies dynamic requests to 127.0.0.1:8571 (-> container :8000) and serves
+# /static/ and /media/ directly, exactly as before -- so it ships via the
+# normal push-to-deploy path with no Apache/IT changes.
+#
+# Gunicorn tuning (overridable via env vars in the compose file):
+#   GUNICORN_WORKERS  number of worker processes. The (2*cores)+1 rule of thumb
+#                     would be ~49 on the 24-core host, but that box is SHARED
+#                     with all Project Sidewalk instances (see #959), so we
+#                     default to a modest 3.
+#   GUNICORN_TIMEOUT  per-request worker timeout in seconds. Gunicorn's default
+#                     of 30s can kill slow admin operations (ImageMagick/PDF
+#                     thumbnail generation), so we default to 120.
 echo "****************** STEP 5/5: docker-entrypoint.sh ************************"
-echo "5. Starting server with 'python manage.py runserver 0.0.0.0:8000'"
-echo "******************************************"
-python manage.py runserver 0.0.0.0:8000
+if [ "$DJANGO_ENV" = "TEST" ] || [ "$DJANGO_ENV" = "PROD" ]; then
+  GUNICORN_WORKERS="${GUNICORN_WORKERS:-3}"
+  GUNICORN_TIMEOUT="${GUNICORN_TIMEOUT:-120}"
+  echo "5. Starting Gunicorn (DJANGO_ENV=$DJANGO_ENV, workers=$GUNICORN_WORKERS, timeout=${GUNICORN_TIMEOUT}s)"
+  echo "******************************************"
+  exec gunicorn makeabilitylab.wsgi:application \
+    --bind 0.0.0.0:8000 \
+    --workers "$GUNICORN_WORKERS" \
+    --timeout "$GUNICORN_TIMEOUT" \
+    --access-logfile - \
+    --error-logfile -
+else
+  echo "5. Starting dev server with 'python manage.py runserver 0.0.0.0:8000' (DJANGO_ENV=$DJANGO_ENV)"
+  echo "******************************************"
+  exec python manage.py runserver 0.0.0.0:8000
+fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -117,6 +117,23 @@ django-prose-editor[sanitize]==0.26.0
 
 
 # -----------------------------------------------------------------------------
+# WSGI Server (production)
+# -----------------------------------------------------------------------------
+# Gunicorn is the production WSGI server. We previously ran Django's dev
+# `runserver` on test AND prod, which the Django docs explicitly warn against
+# ("DO NOT USE THIS SERVER IN A PRODUCTION SETTING ... has not gone through
+# security audits or performance tests"). See issue #1034.
+#
+# Gunicorn runs inside the same container behind UW CSE's Apache reverse proxy
+# (Apache still serves /static/ and /media/ directly and proxies dynamic
+# requests to 127.0.0.1:8571 -> container :8000), so this swap is contained to
+# the container and ships via the normal push-to-deploy path -- no Apache or
+# UW CSE IT changes required. Worker count and request timeout are tunable via
+# the GUNICORN_WORKERS / GUNICORN_TIMEOUT env vars in docker-entrypoint.sh.
+# See: https://docs.djangoproject.com/en/5.2/howto/deployment/wsgi/gunicorn/
+gunicorn==23.0.0
+
+# -----------------------------------------------------------------------------
 # Security & Networking
 # -----------------------------------------------------------------------------
 # pyOpenSSL - Python wrapper around OpenSSL


### PR DESCRIPTION
Closes #1034.

Swaps Django's dev `runserver` for Gunicorn on test/prod. The Django docs explicitly warn against `runserver` in production ("has not gone through security audits or performance tests"), yet we've run it on both test and prod since 2017.

### Key point: no UW CSE IT involvement needed
The Django process runs *inside our Docker container*, behind UW CSE's Apache reverse proxy (`127.0.0.1:8571` → container `:8000`). Swapping the in-container server leaves the port mapping and everything Apache sees identical, so this ships via the normal push-to-deploy path — push to `master` → test, tag → prod. No Apache edits, no IT ticket.

One thing worth confirming with @mechanicjay (verification only): that Apache serves `/static/` and `/media/` from the filesystem rather than proxying them to the container. Almost certainly yes — prod runs `DEBUG=False`, and `runserver` refuses to serve static when `DEBUG=False`, yet our CSS/JS work in prod.

### Changes
- **`requirements.txt`**: add `gunicorn==23.0.0`.
- **`docker-entrypoint.sh`**: start Gunicorn when `DJANGO_ENV` is `TEST`/`PROD`; keep `runserver` for local dev (`DJANGO_ENV=DEBUG`) so auto-reload, the debug toolbar, and `DEBUG=True` static serving still work. Uses `exec` so the server becomes PID 1 and receives Docker's stop signals.

### Tuning (overridable via env vars)
- `GUNICORN_WORKERS` defaults to **3** — the `(2*cores)+1` rule of thumb would be ~49 on the 24-core host, but that box is shared with all Project Sidewalk instances (#959), so we stay conservative.
- `GUNICORN_TIMEOUT` defaults to **120s** — Gunicorn's default 30s could kill slow ImageMagick/PDF thumbnail generation.

### Why this is not a latency fix
The #959 slowness was N+1 queries (since fixed via the ORM). Gunicorn won't speed up a single render; it makes serving production-grade (security, managed workers, crash-restart, request timeouts).

### Test plan
1. Merge to `master` → auto-deploys to `makeabilitylab-test`.
2. On `-test`: browse pages; save an admin record with an image upload (exercises the 120s timeout path); confirm `/static/` and `/media/` still load.
3. If clean, tag a release for prod. Trivially reversible — revert two lines, redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
