### PR TITLE
Report live WSGI server in /version to confirm Gunicorn (#1034)

### DIFF
--- a/website/tests/test_version_endpoint.py
+++ b/website/tests/test_version_endpoint.py
@@ -56,6 +56,17 @@ class VersionResponseTests(SimpleTestCase):
         # Always present, even without a build-info file.
         self.assertIn("git_sha", data)
         self.assertIn("built_at", data)
+        # The live WSGI server's self-reported SERVER_SOFTWARE (#1034); always
+        # present so we can confirm gunicorn vs. the dev runserver in deploys.
+        self.assertIn("server", data)
+
+    def test_server_reflects_wsgi_server_software(self):
+        # The view reports request.META["SERVER_SOFTWARE"] verbatim; on the real
+        # servers that's "gunicorn/<ver>" after #1034. Simulate it here.
+        data = json.loads(
+            self.client.get("/version/", SERVER_SOFTWARE="gunicorn/23.0.0").content
+        )
+        self.assertEqual(data["server"], "gunicorn/23.0.0")
 
     def test_build_info_missing_falls_back_to_unknown(self):
         with override_settings():

--- a/website/views/version.py
+++ b/website/views/version.py
@@ -25,8 +25,14 @@ Example::
       "description": "Fix the project listing page ...",
       "environment": "PROD",
       "git_sha": "02909b0",
-      "built_at": "2026-06-21T18:30:00-07:00"
+      "built_at": "2026-06-21T18:30:00-07:00",
+      "server": "gunicorn/23.0.0"
     }
+
+The ``server`` field is the WSGI server's self-reported ``SERVER_SOFTWARE``
+(``gunicorn/<ver>`` vs. Django's ``WSGIServer/<ver> CPython/<ver>``), read off
+the live request -- it's the ground-truth answer to *"is this actually running
+Gunicorn?"* after the #1034 swap, not an inference from env vars or git_sha.
 """
 
 import json
@@ -83,6 +89,9 @@ def version(request, format=None):
         "environment": settings.DJANGO_ENV or "unknown",
         "git_sha": build_info["git_sha"],
         "built_at": build_info["built_at"],
+        # WSGI server handling this request: "gunicorn/<ver>" under #1034,
+        # "WSGIServer/<ver> CPython/<ver>" if the dev runserver is somehow live.
+        "server": request.META.get("SERVER_SOFTWARE", "unknown"),
     }
     response = JsonResponse(payload)
     response["Cache-Control"] = "no-store"


### PR DESCRIPTION
Follow-up to #1385 (Gunicorn swap, #1034).

Adds a `server` field to the `/version` JSON, read from the live request's `SERVER_SOFTWARE`, so a deploy can be confirmed to actually be running Gunicorn rather than inferred from the git SHA.

This commit was pushed to the `1034-gunicorn` branch just after #1385 merged, so it never made it into that PR — hence this small follow-up.

### What you'll see after deploy
```json
GET /version/
{
  "version": "2.20.0",
  "environment": "TEST",
  "git_sha": "9fc6755",
  "built_at": "...",
  "server": "gunicorn/23.0.0"      ← ground truth; "WSGIServer/0.2 CPython/3.13.1" would mean runserver
}
```

### Changes
- `website/views/version.py`: add `"server": request.META.get("SERVER_SOFTWARE", "unknown")` (+ docstring).
- `website/tests/test_version_endpoint.py`: pin the field's presence and that it reflects `SERVER_SOFTWARE`. Full `/version` suite (7 tests) passes in the container.

Note: locally `/version` shows `WSGIServer/...` by design — local dev keeps `runserver`; Gunicorn only runs when `DJANGO_ENV` is `TEST`/`PROD`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
