### PR TITLE
Remove dead Banner cruft from views (#661)

### DIFF
--- a/website/views/member.py
+++ b/website/views/member.py
@@ -87,12 +87,8 @@ def member(request, member_name=None, member_id=None):
         raise Http404("No person matches the given query.")
 
     news_items_num = 5  # Defines the number of news items that will be selected
-    # all_banners = Banner.objects.filter(page=Banner.PEOPLE)
-    # displayed_banners = ml_utils.choose_banners(all_banners)
 
-    
-
-    # Returns QuerySet of News objects that mention the specified person. 
+    # Returns QuerySet of News objects that mention the specified person.
     # The order_by('-date') part sorts the QuerySet by date in descending order 
     # (so the most recent news comes first), and [:4] limits the QuerySet to 
     # the first 4 objects.
@@ -146,7 +142,6 @@ def member(request, member_name=None, member_id=None):
                'mobile_page_sizes': ARTIFACT_MOBILE_PAGE_SIZES,
                'project_roles': project_roles,
                'position' : latest_position,
-               # 'banners': displayed_banners,
                'left_align_headers': left_align_headers,
                'debug': settings.DEBUG,
                'navbar_white': True,

--- a/website/views/news_listing.py
+++ b/website/views/news_listing.py
@@ -1,5 +1,5 @@
 from django.conf import settings # for access to settings variables, see https://docs.djangoproject.com/en/4.0/topics/settings/#using-settings-in-python-code
-from website.models import Banner, News
+from website.models import News
 import datetime
 import website.utils.ml_utils as ml_utils 
 from django.shortcuts import render

--- a/website/views/people.py
+++ b/website/views/people.py
@@ -1,5 +1,5 @@
 from django.conf import settings # for access to settings variables, see https://docs.djangoproject.com/en/4.0/topics/settings/#using-settings-in-python-code
-from website.models import Banner, Position, Person, Publication
+from website.models import Position, Person, Publication
 from website.models.position import Role
 from website.models.publication import PubType
 import website.utils.ml_utils as ml_utils 


### PR DESCRIPTION
Closes #661 (closed as obsolete) by removing the dead code it leaves behind.

## What & why
Issue #661 (2018) asked for banners on multiple pages/projects, built around an old admin `Page:` dropdown that no longer exists. The `Banner` model was since refactored to `landing_page` (boolean) + a single `project` FK, and banners render only on the **landing page** and **one project page**.

The "other page types" (People/News) design was never wired up — it survived only as dead stubs:
- `website/views/member.py` — commented `Banner.objects.filter(page=Banner.PEOPLE)` / `displayed_banners` lines + the commented `'banners'` context entry
- `website/views/people.py` — unused `Banner` import
- `website/views/news_listing.py` — unused `Banner` import

This PR deletes all of it. `ml_utils` is kept in `member.py` (still used elsewhere).

## Scope
No behavior change — purely removing commented/unused code. No model, template, or URL changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)