### PR TITLE
Shrink mobile footer logo so the mission blurb gets more room (#1395)

### DIFF
--- a/website/static/website/css/footer.css
+++ b/website/static/website/css/footer.css
@@ -341,7 +341,9 @@
   .makelab-footer-logo {
     float: left;
     width: 100%;
-    max-width: 180px;
+    /* Shrink the logo on phones so the mission blurb gets more vertical room
+       (#1395). Was 180px, which dominated the narrow single-column layout. */
+    max-width: 110px;
   }
 
   .makelab-footer-connect-links-mobile {


### PR DESCRIPTION
Closes #1395.

## What
On phones (≤550px) the footer Makeability Lab logo stayed at `max-width: 180px`, dominating the single-column layout and squeezing the "We design, build, and evaluate…" mission text. This drops it to **110px** on phones.

CSS-only, one rule in `footer.css`. No JS, no markup changes.

## Before / after
<!-- Add before/after mobile screenshots here (CONTRIBUTING.md requires them for UI changes). -->

## Testing
- [ ] Verify on a phone-width viewport (≤550px) that the logo is smaller and the mission text has more room.
- [ ] Run Pa11y before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)