### PR TITLE
Add image preview + square cropping to Awards admin badge (#1408)

### DIFF
--- a/website/admin/award_admin.py
+++ b/website/admin/award_admin.py
@@ -1,7 +1,11 @@
+import os
+
 from django import forms
 from django.contrib import admin
 from django.urls import reverse
 from django.utils.html import format_html
+from easy_thumbnails.files import get_thumbnailer
+from image_cropping import ImageCroppingMixin
 from website.models import Award
 from website.admin.admin_site import ml_admin_site
 from sortedm2m_filter_horizontal_widget.forms import SortedFilteredSelectMultiple
@@ -28,12 +32,12 @@ class AwardAdminForm(forms.ModelForm):
 
 
 @admin.register(Award, site=ml_admin_site)
-class AwardAdmin(admin.ModelAdmin):
+class AwardAdmin(ImageCroppingMixin, admin.ModelAdmin):
     form = AwardAdminForm
 
     # get_recipient_names / get_project_names are methods on the Award model;
     # their column headers come from each method's short_description.
-    list_display = ('title', 'organization', 'date',
+    list_display = ('title', 'get_display_thumbnail', 'organization', 'date',
                     'get_recipient_names', 'get_project_names', 'award_type')
 
     list_filter = ('award_type', 'date')
@@ -80,7 +84,7 @@ class AwardAdmin(admin.ModelAdmin):
                 'fields': ['url', 'description'],
             }),
             ('Display', {
-                'fields': ['badge', 'badge_alt_text'],
+                'fields': ['badge', 'badge_cropping', 'badge_alt_text'],
                 'description': 'Optional. On the Awards page, faculty honors show a medal icon, '
                                'student awards show the recipient’s photo, and project awards '
                                'show the project thumbnail. Upload a badge/logo here to override '
@@ -98,3 +102,18 @@ class AwardAdmin(admin.ModelAdmin):
         if db_field.name == 'recipients' or db_field.name == 'projects':
             kwargs['widget'] = SortedFilteredSelectMultiple()
         return super().formfield_for_manytomany(db_field, request, **kwargs)
+
+    def get_display_thumbnail(self, obj):
+        """Square preview of the uploaded badge (with its crop applied) in the
+        changelist, mirroring the SponsorAdmin/NewsAdmin logo columns. Awards
+        without a custom badge fall back to a medal icon on the public page, so
+        there's nothing to show here."""
+        if obj.badge and os.path.isfile(obj.badge.path):
+            thumbnailer = get_thumbnailer(obj.badge)
+            options = {'size': (50, 50), 'crop': True, 'box': obj.badge_cropping}
+            thumbnail_url = thumbnailer.get_thumbnail(options).url
+            return format_html('<img src="{}" height="50" width="50" '
+                               'style="object-fit: cover; border-radius: 5%;"/>', thumbnail_url)
+        return '—'
+
+    get_display_thumbnail.short_description = 'Badge'

--- a/website/models/award.py
+++ b/website/models/award.py
@@ -1,6 +1,8 @@
 from django.db import models
 from sortedm2m.fields import SortedManyToManyField
 
+from image_cropping import ImageRatioField
+
 from website.utils.fileutils import UniquePathAndRename
 from website.utils.upload_validators import validate_image_upload
 
@@ -71,6 +73,14 @@ class Award(models.Model):
                        "organization's logo). Faculty honors otherwise show a medal icon. "
                        "Student awards default to the recipient's photo and project awards to "
                        "the project thumbnail; uploading a badge overrides those.")
+
+    # Square crop box for the badge, applied on the public Awards page so every
+    # anchor (badge, portrait, project thumbnail, medal) reads as a uniform square
+    # tile. Stored as an "x1,y1,x2,y2" string; the admin shows a Cropper.js preview
+    # before the first save (same pattern as Person.cropping / Sponsor.icon_cropping).
+    badge_cropping = ImageRatioField('badge', '245x245', size_warning=True)
+    badge_cropping.help_text = ("Crop the badge to a square using the preview above "
+                                "(no need to save first). Keeps award anchors uniform.")
 
     badge_alt_text = models.CharField(max_length=255, blank=True, null=True)
     badge_alt_text.help_text = "Alt text for the badge image. Defaults to the award title if left blank."

--- a/website/static/website/css/awards.css
+++ b/website/static/website/css/awards.css
@@ -80,10 +80,11 @@
   border-radius: 50%;
 }
 
-/* Uploaded emblem/logo: show whole (don't crop) and let it sit on the page. */
+/* Uploaded emblem/logo: editors square-crop it in the admin (Award.badge_cropping),
+   so it fills the same square tile as the portrait/thumbnail anchors for a uniform
+   row. The shared .award-anchor-img rules already supply object-fit: cover + border. */
 .award-anchor-badge {
-  object-fit: contain;
-  border: none;
+  border-radius: var(--border-radius-md);
 }
 
 /* Faculty honors: medal icon in a soft circular chip. */

--- a/website/templates/snippets/display_award_snippet.html
+++ b/website/templates/snippets/display_award_snippet.html
@@ -25,7 +25,8 @@ markup stays free of inline styles.
 
   <div class="award-anchor" aria-hidden="true">
     {% if kind == 'badge' %}
-      <img class="award-anchor-img award-anchor-badge" src="{{ award.badge.url }}" alt="">
+      <img class="award-anchor-img award-anchor-badge"
+           src="{% thumbnail award.badge 245x245 box=award.badge_cropping crop upscale %}" alt="">
     {% elif kind == 'portrait' %}
       {% with person=award.get_portrait_person %}
       <img class="award-anchor-img award-anchor-portrait"

--- a/website/tests/test_image_cropping.py
+++ b/website/tests/test_image_cropping.py
@@ -172,6 +172,13 @@ class PersonCropMetadataTests(SimpleTestCase):
         self.assertIn("cropping", Person.ratio_fields)
         self.assertIn("easter_egg_crop", Person.ratio_fields)
 
+    def test_award_badge_exposes_crop_fields(self):
+        """Award.badge gained a square crop so its public anchor stays uniform."""
+        from website.models import Award
+
+        self.assertIn("badge", Award.crop_fields)
+        self.assertIn("badge_cropping", Award.ratio_fields)
+
 
 # --- Admin uses the Cropper.js widget, not Jcrop ---------------------------
 
@@ -204,5 +211,18 @@ class CropWidgetTests(SimpleTestCase):
         request = MagicMock()
         request.user = AnonymousUser()
         db_field = Person._meta.get_field("image")
+        formfield = admin_obj.formfield_for_dbfield(db_field, request)
+        self.assertIsInstance(formfield.widget, CropImageWidget)
+
+    def test_award_admin_badge_field_uses_crop_widget(self):
+        from django.contrib.auth.models import AnonymousUser
+        from image_cropping.widgets import CropImageWidget
+        from website.models import Award
+        from website.admin.admin_site import ml_admin_site
+
+        admin_obj = ml_admin_site._registry[Award]
+        request = MagicMock()
+        request.user = AnonymousUser()
+        db_field = Award._meta.get_field("badge")
         formfield = admin_obj.formfield_for_dbfield(db_field, request)
         self.assertIsInstance(formfield.widget, CropImageWidget)


### PR DESCRIPTION
Closes #1408.

## What & why
The new Awards admin badge upload didn't follow our standard image-upload pattern (People headshots, News thumbnails, Sponsor logos): no instant client-side preview, no cropping. This applies the established `ImageCroppingMixin` + `ImageRatioField` (Cropper.js) pattern to `Award.badge`.

## Changes
- **`website/models/award.py`** — new `badge_cropping` square (`245x245`) `ImageRatioField`. Square matches the Person portrait / Sponsor icon anchors, so every award-row anchor (badge, portrait, project thumbnail, medal) reads as a uniform square tile. Stores an `"x1,y1,x2,y2"` box string; no committed migration (migrations are gitignored, auto-generated on container start).
- **`website/admin/award_admin.py`** — `AwardAdmin` subclasses `ImageCroppingMixin` (Cropper.js preview/crop before first save); `badge_cropping` added to the **Display** fieldset; new square "Badge" thumbnail column on the changelist (mirrors `SponsorAdmin`/`NewsAdmin`).
- **`website/templates/snippets/display_award_snippet.html`** — badge anchor now renders through `{% thumbnail award.badge 245x245 box=award.badge_cropping crop upscale %}` so the stored crop is applied (was raw `badge.url`).
- **`website/static/website/css/awards.css`** — `.award-anchor-badge` switched from `object-fit: contain`/borderless to the shared square `cover`+border tile for uniformity.
- **`website/tests/test_image_cropping.py`** — regression tests pinning the `Award.badge` crop metadata and that `AwardAdmin` resolves the badge field to the Cropper.js widget.

## Notes
- **Square crop is intentional** — keeps the public Awards row uniform; editors re-crop on upload.
- **Existing badges** keep a blank crop box until re-saved; `crop_corners` treats blank as "no box" and center-crops, so nothing breaks meanwhile (they'll look best after a quick re-crop).

## Testing
- `test_image_cropping` + `test_award` suites pass (28 tests); `manage.py check` clean.
- ⚠️ **TODO before merge (UI change):** add before/after screenshots of an award card and run the Pa11y a11y service per CONTRIBUTING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)