### PR TITLE
auto-deploy: stop tag pushes hijacking branch hosts; fix pull order + deploy-on-failure

### DIFF
--- a/auto-deploy/index.php
+++ b/auto-deploy/index.php
@@ -86,16 +86,43 @@ if($gitSystem && $HOSTNAME && $OPERATION){
 	}
 	
 	//Make sure we're doing a TAG or BRANCH as appropriate
-	if(($incomingOp == "tags" && $OPERATION = "TAG") || ($incomingOp == "heads" && $refs[2] == $OPERATION)){
-		//possibly need to clone it or pull it first:
-		
-	        $out = do_clone_or_pull(DEPLOY_KEY,$url,$deploy_to, $OPERATION);
-	        _debug("$out\n");
-		
-	        //The following will ensure we're either on the right branch, or the right tag:
-	        $out = do_checkout_branch($req,$deploy_to, $OPERATION);
-	        _debug("$out\n");
-	
+	// NOTE: the first clause below is `==`, not `=`. It was previously an
+	// assignment, which made the condition true for EVERY tag push regardless of
+	// how this host is configured -- and, worse, reassigned $OPERATION to "TAG"
+	// for the rest of the request. The effect was that a tag push drove a
+	// branch-tracking host (our test server) down the tag code path, leaving its
+	// checkout detached at that tag.
+	if(($incomingOp == "tags" && $OPERATION == "TAG") || ($incomingOp == "heads" && $refs[2] == $OPERATION)){
+
+	        // Order matters, and it differs between the two cases:
+	        //
+	        //  - TAG: fetch first. The tag usually doesn't exist locally yet, so
+	        //    checking it out before fetching would fail.
+	        //  - BRANCH: check out the branch first. `git pull` aborts outright
+	        //    from a detached HEAD ("You are not currently on a branch"), and
+	        //    the old fetch-then-checkout order could never recover from that:
+	        //    the pull failed, the local branch stayed behind, and the deploy
+	        //    ran anyway (see below) -- so the container rebuilt from stale
+	        //    source while looking freshly deployed.
+	        $repo_exists = is_dir($deploy_to) && file_exists($deploy_to . "/.git");
+
+	        if($OPERATION != "TAG" && $repo_exists){
+	                $out = do_checkout_branch($req,$deploy_to, $OPERATION);
+	                _debug("$out\n");
+
+	                $out = do_clone_or_pull(DEPLOY_KEY,$url,$deploy_to, $OPERATION);
+	                _debug("$out\n");
+	        }
+	        else{
+	                //possibly need to clone it or pull it first:
+	                $out = do_clone_or_pull(DEPLOY_KEY,$url,$deploy_to, $OPERATION);
+	                _debug("$out\n");
+
+	                //The following will ensure we're either on the right branch, or the right tag:
+	                $out = do_checkout_branch($req,$deploy_to, $OPERATION);
+	                _debug("$out\n");
+	        }
+
 		//If we're using docker, then do someother stuff
                 if($USE_DOCKER){
 

--- a/auto-deploy/index.php
+++ b/auto-deploy/index.php
@@ -123,6 +123,27 @@ if($gitSystem && $HOSTNAME && $OPERATION){
 	                _debug("$out\n");
 	        }
 
+		// Guard against silently deploying stale source. Historically the
+		// container build below ran unconditionally after checkout/pull, so a
+		// failed pull (detached HEAD, merge conflict, network/ssh error) would
+		// rebuild from STALE source while looking freshly deployed. Confirm the
+		// checked-out HEAD is the commit that was actually pushed ($req['after'])
+		// before building. If the payload carries no usable SHA we fall back to
+		// deploying (preserves prior behavior rather than risk blocking a deploy).
+		// (On rapid successive pushes HEAD may already be a *newer* commit than
+		// this event's 'after'; skipping here is safe -- the newer push's hook
+		// deploys the newer state.)
+		$expected_sha = isset($req['after']) ? strtolower(trim($req['after'])) : "";
+		$has_sha = ($expected_sha !== "" && !preg_match('/^0+$/', $expected_sha));
+		$head_sha = strtolower(trim(shell_exec("bash -c 'cd $deploy_to; git rev-parse HEAD' 2>/dev/null")));
+
+		if($has_sha && $head_sha !== "" && $head_sha !== $expected_sha){
+			_log("ABORTING DEPLOY: checked-out HEAD ($head_sha) does not match the ".
+			     "pushed commit ($expected_sha) -- the pull/checkout above likely ".
+			     "failed. Refusing to rebuild the container from stale source.\n");
+			exit;
+		}
+
 		//If we're using docker, then do someother stuff
                 if($USE_DOCKER){
 
@@ -222,7 +243,7 @@ function do_checkout_branch($req, $deployto, $operation){
  */
 function determine_branch_name( $request) {
     // push request, branch is in request[ref]
-    if (isset($reqest['ref'])) {
+    if (isset($request['ref'])) {
         // strip out the refs/head nonsense -- doesn't look like bare
         // branch is listed anywhere in the request
         return preg_replace("|refs/heads/|", "", $request['ref']);
@@ -307,18 +328,24 @@ function do_clone($key,$url,$path) {
  * Log a message, only here to make some messages easy to turn off.
  */
 function _trace($message) {
-    if ($trace = TRUE) {
+    // NOTE: was `if ($trace = TRUE)` -- an assignment, not a comparison, so it
+    // was always true and could never be turned off (same =/== footgun fixed in
+    // the deploy condition above). Default to on to preserve prior behavior;
+    // config.php can silence it with `define('AUTODEPLOY_TRACE', false);`.
+    if (defined('AUTODEPLOY_TRACE') ? AUTODEPLOY_TRACE : TRUE) {
         _log($message);
-    } 
+    }
 }
 
 /**
  * Log a message, only here to make some messages easy to turn off.
  */
 function _debug($message) {
-    if ($debug = TRUE) {
+    // Same fix as _trace(): `$debug = TRUE` was an assignment, always true.
+    // Default on; silence via `define('AUTODEPLOY_DEBUG', false);` in config.php.
+    if (defined('AUTODEPLOY_DEBUG') ? AUTODEPLOY_DEBUG : TRUE) {
         _log($message);
-    } 
+    }
 }
 
 /**

--- a/auto-deploy/index.php
+++ b/auto-deploy/index.php
@@ -64,7 +64,17 @@ if (!$gitSystem) {
 
 //Make a determiniation if the incoming operation is right for this system.
 if($gitSystem && $HOSTNAME && $OPERATION){
-	$refs=explode("/",$req['ref']);
+	// The ref is interpolated into shell commands further down (`git checkout
+	// <ref>`) and this endpoint is unauthenticated, so accept only a plain,
+	// well-formed ref name and refuse anything else. Without this, a crafted
+	// payload could smuggle shell metacharacters through to shell_exec().
+	$incoming_ref = isset($req['ref']) ? trim($req['ref']) : "";
+	if(!preg_match('#^refs/(heads|tags)/[A-Za-z0-9._/-]+$#', $incoming_ref)){
+		_log("Refusing to act on a malformed or unsupported ref: " . json_encode($incoming_ref) . "\n");
+		exit;
+	}
+
+	$refs=explode("/",$incoming_ref);
 	$incomingOp=$refs[1]; // should be tags or heads
 	
 	//Some initial validation, make sure this is a configured repo and stuff
@@ -133,13 +143,31 @@ if($gitSystem && $HOSTNAME && $OPERATION){
 		// (On rapid successive pushes HEAD may already be a *newer* commit than
 		// this event's 'after'; skipping here is safe -- the newer push's hook
 		// deploys the newer state.)
+		//
+		// IMPORTANT: 'after' is the ref's new VALUE, which for an ANNOTATED tag is
+		// the tag OBJECT's sha -- not the commit's. `git checkout refs/tags/X`
+		// leaves HEAD at the COMMIT, so a raw sha comparison would abort every
+		// annotated-tag deploy, i.e. every production release (2.27.0/.2/.3 are all
+		// annotated). Peel with `^{commit}` before comparing.
 		$expected_sha = isset($req['after']) ? strtolower(trim($req['after'])) : "";
-		$has_sha = ($expected_sha !== "" && !preg_match('/^0+$/', $expected_sha));
-		$head_sha = strtolower(trim(shell_exec("bash -c 'cd $deploy_to; git rev-parse HEAD' 2>/dev/null")));
+		$has_sha = preg_match('/^[0-9a-f]{40}$/', $expected_sha) && !preg_match('/^0+$/', $expected_sha);
 
-		if($has_sha && $head_sha !== "" && $head_sha !== $expected_sha){
+		$head_sha = "";
+		$expected_commit = "";
+		if($has_sha){
+			$head_sha = strtolower(trim(shell_exec("bash -c 'cd $deploy_to; git rev-parse HEAD' 2>/dev/null")));
+			$expected_commit = strtolower(trim(shell_exec(
+				"bash -c 'cd $deploy_to; git rev-parse --verify --quiet {$expected_sha}^{commit}' 2>/dev/null")));
+		}
+
+		// Fail SAFE: abort only when we positively know HEAD is the wrong commit.
+		// A sha we can't resolve locally (fetch failed, unusual payload, ...) falls
+		// through to the historical deploy-anyway behavior rather than blocking a
+		// release on a check we aren't sure about.
+		if($head_sha !== "" && $expected_commit !== "" && $head_sha !== $expected_commit){
 			_log("ABORTING DEPLOY: checked-out HEAD ($head_sha) does not match the ".
-			     "pushed commit ($expected_sha) -- the pull/checkout above likely ".
+			     "pushed commit ($expected_commit, from ref value $expected_sha) -- ".
+			     "the pull/checkout above likely ".
 			     "failed. Refusing to rebuild the container from stale source.\n");
 			exit;
 		}


### PR DESCRIPTION
## What & why

Hardens the GitLab/GitHub auto-deploy webhook (`auto-deploy/index.php`).

### 1. Tag pushes hijacking branch hosts (the headline bug)
The condition `($incomingOp == "tags" && $OPERATION = "TAG")` used `=` (assignment) instead of `==`. That made the clause true for **every** tag push regardless of host config, and reassigned `$OPERATION` to `"TAG"` for the rest of the request — so a tag push drove the branch-tracking **test** server down the tag code path, leaving its checkout detached at that tag. Fixed to `==`.

### 2. Pull/checkout order
`git pull` aborts from a detached HEAD ("You are not currently on a branch"). For **branch** hosts we now `checkout` first, then `pull`; for **tag** hosts we fetch first (the tag usually isn't local yet). Prod's tag path is unchanged in the happy case.

### 3. Deploy-on-failure gate (from code review)
The container build ran **unconditionally** after checkout/pull, so any pull failure still rebuilt from stale source while looking freshly deployed. Now we confirm the checked-out `HEAD` equals the pushed commit (`$req['after']`) before building; abort + log on mismatch. **Fail-safe:** if the payload has no usable SHA, deploy as before (never blocks a legit deploy).

### 4. Same `=`/`==` footgun, twice more
`_trace()`/`_debug()` guarded on `if ($x = TRUE)` — always true, never disableable. Fixed to a `defined()` toggle (default on; silence via `define('AUTODEPLOY_TRACE'/'AUTODEPLOY_DEBUG', false)` in config.php).

### 5. `determine_branch_name()` typo
Guarded on misspelled `$reqest` → always returned null (branch fast-path was dead code). Fixed to `$request`.

### 6. Deploy gate: peel annotated tags (would have blocked every prod release)
Follow-up to #3. `$req['after']` is the ref's new **value**, which for an
**annotated** tag is the tag *object's* sha, while `git checkout refs/tags/X`
leaves `HEAD` at the *commit*. Tags 2.27.0 / 2.27.2 / 2.27.3 are all annotated,
so the gate as first written would have aborted every production deploy. The
expected sha is now peeled with `^{commit}` before comparing, and the gate is
skipped entirely (deploy proceeds, as before) if the sha can't be resolved
locally. Verified against real git: annotated tag object `e109d61…` peels to
commit `3c746b3…`, which is what `HEAD` reads after the tag checkout.

### 7. Validate the incoming ref before it reaches a shell
`$req['ref']` was interpolated straight into `git checkout <ref>` via
`shell_exec()` on an **unauthenticated** endpoint (no webhook-secret /
signature check anywhere in this script), so a crafted payload naming our
public repo URL could smuggle shell metacharacters onto the deploy host. The
ref must now match `refs/(heads|tags)/[A-Za-z0-9._/-]+`; anything else is
logged and refused. Normal refs (`refs/heads/master`,
`refs/heads/dependabot/pip/pypdf-6.14.2`, `refs/tags/2.27.3`) are unaffected.

## Testing
- `php -l` clean (no local PHP runtime; linted in a throwaway `php:8-cli-alpine` container).
- No automated harness exists for this PHP webhook; the deploy gate is written fail-safe (falls back to prior behavior on any ambiguity) precisely because it can't be exercised end-to-end off-server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
